### PR TITLE
Implement internal legacy Office conversion

### DIFF
--- a/src/binaryOfficeConversion.js
+++ b/src/binaryOfficeConversion.js
@@ -1,0 +1,234 @@
+const path = require('path')
+const os = require('os')
+const { promises: fs } = require('fs')
+
+const EOCD_SIGNATURE = 0x06054b50
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50
+
+const MIN_LINE_LENGTH = 3
+
+const BINARY_OFFICE_KINDS = {
+  '.doc': 'word',
+  '.dot': 'word',
+  '.ppt': 'presentation',
+  '.pps': 'presentation',
+  '.pot': 'presentation',
+  '.xls': 'spreadsheet',
+  '.xlt': 'spreadsheet'
+}
+
+const escapeXml = (input) => {
+  if (!input) return ''
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+const toDosDateTime = (date) => {
+  const year = Math.max(1980, date.getFullYear())
+  const dosDate = ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+  const dosTime = (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2)
+  return { dosDate, dosTime }
+}
+
+const crc32Table = new Uint32Array(256).map((_, index) => {
+  let c = index
+  for (let k = 0; k < 8; k++) {
+    if (c & 1) {
+      c = 0xedb88320 ^ (c >>> 1)
+    } else {
+      c >>>= 1
+    }
+  }
+  return c >>> 0
+})
+
+const crc32 = (buffer) => {
+  let crc = 0 ^ 0xffffffff
+  for (let i = 0; i < buffer.length; i++) {
+    const byte = buffer[i]
+    crc = crc32Table[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+const createStoredZip = (files) => {
+  const localParts = []
+  const centralParts = []
+  let offset = 0
+  const now = new Date()
+  const { dosDate, dosTime } = toDosDateTime(now)
+
+  for (const file of files) {
+    const nameBuffer = Buffer.from(file.name, 'utf8')
+    const dataBuffer = Buffer.isBuffer(file.data) ? file.data : Buffer.from(file.data, 'utf8')
+    const crc = crc32(dataBuffer)
+
+    const localHeader = Buffer.alloc(30)
+    localHeader.writeUInt32LE(LOCAL_FILE_HEADER_SIGNATURE, 0)
+    localHeader.writeUInt16LE(20, 4)
+    localHeader.writeUInt16LE(0, 6)
+    localHeader.writeUInt16LE(0, 8)
+    localHeader.writeUInt16LE(dosTime, 10)
+    localHeader.writeUInt16LE(dosDate, 12)
+    localHeader.writeUInt32LE(crc, 14)
+    localHeader.writeUInt32LE(dataBuffer.length, 18)
+    localHeader.writeUInt32LE(dataBuffer.length, 22)
+    localHeader.writeUInt16LE(nameBuffer.length, 26)
+    localHeader.writeUInt16LE(0, 28)
+
+    const localEntry = Buffer.concat([localHeader, nameBuffer, dataBuffer])
+    localParts.push(localEntry)
+
+    const centralHeader = Buffer.alloc(46)
+    centralHeader.writeUInt32LE(CENTRAL_DIRECTORY_SIGNATURE, 0)
+    centralHeader.writeUInt16LE(0x0314, 4)
+    centralHeader.writeUInt16LE(20, 6)
+    centralHeader.writeUInt16LE(0, 8)
+    centralHeader.writeUInt16LE(0, 10)
+    centralHeader.writeUInt16LE(dosTime, 12)
+    centralHeader.writeUInt16LE(dosDate, 14)
+    centralHeader.writeUInt32LE(crc, 16)
+    centralHeader.writeUInt32LE(dataBuffer.length, 20)
+    centralHeader.writeUInt32LE(dataBuffer.length, 24)
+    centralHeader.writeUInt16LE(nameBuffer.length, 28)
+    centralHeader.writeUInt16LE(0, 30)
+    centralHeader.writeUInt16LE(0, 32)
+    centralHeader.writeUInt16LE(0, 34)
+    centralHeader.writeUInt16LE(0, 36)
+    centralHeader.writeUInt32LE(0, 38)
+    centralHeader.writeUInt32LE(offset, 42)
+
+    const centralEntry = Buffer.concat([centralHeader, nameBuffer])
+    centralParts.push(centralEntry)
+
+    offset += localEntry.length
+  }
+
+  const localSection = Buffer.concat(localParts)
+  const centralSection = Buffer.concat(centralParts)
+
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(EOCD_SIGNATURE, 0)
+  eocd.writeUInt16LE(0, 4)
+  eocd.writeUInt16LE(0, 6)
+  eocd.writeUInt16LE(files.length, 8)
+  eocd.writeUInt16LE(files.length, 10)
+  eocd.writeUInt32LE(centralSection.length, 12)
+  eocd.writeUInt32LE(localSection.length, 16)
+  eocd.writeUInt16LE(0, 20)
+
+  return Buffer.concat([localSection, centralSection, eocd])
+}
+
+const collectSegments = (text, matchRegex, stripRegex) => {
+  if (!text) return []
+  const matches = text.match(matchRegex) || []
+  const results = []
+  for (const match of matches) {
+    const cleaned = match
+      .replace(stripRegex, ' ')
+      .replace(/\r\n?/g, '\n')
+      .split('\n')
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .filter(Boolean)
+    results.push(...cleaned)
+  }
+  return results
+}
+
+const extractBinaryLines = (buffer) => {
+  const lines = []
+  const seen = new Set()
+
+  const pushLines = (candidates) => {
+    for (const candidate of candidates) {
+      if (!candidate || candidate.length < MIN_LINE_LENGTH) continue
+      if (seen.has(candidate)) continue
+      seen.add(candidate)
+      lines.push(candidate)
+    }
+  }
+
+  const asciiText = buffer.toString('latin1')
+  pushLines(collectSegments(asciiText, /[\x20-\x7E\s]{4,}/g, /[^\x20-\x7E\s]/g))
+
+  const unicodeText = buffer.toString('utf16le')
+  pushLines(collectSegments(unicodeText, /[\u0020-\uD7FF\uE000-\uFFFD\s]{4,}/g, /[^\u0020-\uD7FF\uE000-\uFFFD\s]/g))
+
+  const utf8Text = buffer.toString('utf8')
+  pushLines(collectSegments(utf8Text, /[\u0020-\uD7FF\uE000-\uFFFD\s]{4,}/g, /[^\u0020-\uD7FF\uE000-\uFFFD\s]/g))
+
+  return lines
+}
+
+const buildDocxBuffer = (lines) => {
+  const paragraphs = lines.length > 0 ? lines : ['Converted legacy Office document']
+  const bodyContent = paragraphs.map((line) => {
+    return `<w:p><w:r><w:t xml:space="preserve">${escapeXml(line)}</w:t></w:r></w:p>`
+  }).join('')
+
+  const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>${bodyContent}<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr></w:body>
+</w:document>`
+
+  const contentTypesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`
+
+  const packageRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+
+  const stylesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/><w:qFormat/></w:style>
+</w:styles>`
+
+  const files = [
+    { name: '[Content_Types].xml', data: Buffer.from(contentTypesXml, 'utf8') },
+    { name: '_rels/.rels', data: Buffer.from(packageRelsXml, 'utf8') },
+    { name: 'word/document.xml', data: Buffer.from(documentXml, 'utf8') },
+    { name: 'word/styles.xml', data: Buffer.from(stylesXml, 'utf8') }
+  ]
+
+  return createStoredZip(files)
+}
+
+const convertBinaryOfficeToDocx = async ({ filePath, ext }) => {
+  const kind = BINARY_OFFICE_KINDS[ext]
+  if (!kind) {
+    throw new Error(`Unsupported binary Office extension: ${ext}`)
+  }
+
+  const buffer = await fs.readFile(filePath)
+  const lines = extractBinaryLines(buffer)
+
+  if (lines.length === 0) {
+    throw new Error(`No textual content could be extracted from ${path.basename(filePath)}. The file may require manual conversion.`)
+  }
+
+  const docxBuffer = buildDocxBuffer(lines)
+  const baseName = path.basename(filePath, ext) || 'converted'
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ai-renamer-legacy-'))
+  const tempPath = path.join(tempDir, `${baseName}.docx`)
+  await fs.writeFile(tempPath, docxBuffer)
+
+  const cleanup = async () => {
+    await fs.rm(tempDir, { recursive: true, force: true })
+  }
+
+  return { tempPath, cleanup }
+}
+
+module.exports = { convertBinaryOfficeToDocx }

--- a/src/configureYargs.js
+++ b/src/configureYargs.js
@@ -77,6 +77,12 @@ module.exports = async () => {
       alias: 'r',
       type: 'string',
       description: 'Add a custom prompt to the LLM (e.g. "Only describe the background")'
+    })
+    .option('convertbinary', {
+      alias: 'convert-binary',
+      type: 'boolean',
+      description: 'Convert legacy binary Microsoft Office documents before parsing',
+      default: config.defaultConvertBinary || false
     }).argv
 
   if (argv.help) {
@@ -131,6 +137,11 @@ module.exports = async () => {
 
   if (argv['custom-prompt']) {
     config.defaultCustomPrompt = argv['custom-prompt']
+    await saveConfig({ config })
+  }
+
+  if (process.argv.includes('--convertbinary') || process.argv.includes('--convert-binary') || process.argv.includes('--no-convertbinary') || process.argv.includes('--no-convert-binary')) {
+    config.defaultConvertBinary = argv.convertbinary
     await saveConfig({ config })
   }
 

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -12,7 +12,7 @@ const isProcessableFile = require('./isProcessableFile')
 
 module.exports = async options => {
   try {
-    const { frames, filePath, inputPath } = options
+    const { frames, filePath, inputPath, convertBinary } = options
 
     const fileName = path.basename(filePath)
     const ext = path.extname(filePath).toLowerCase()
@@ -41,7 +41,7 @@ module.exports = async options => {
       images = _extractedFrames.images
       videoPrompt = _extractedFrames.videoPrompt
     } else {
-      content = await readFileContent({ filePath })
+      content = await readFileContent({ filePath, convertBinary })
       if (!content) {
         console.log(`🔴 No text content: ${relativeFilePath}`)
         return

--- a/src/processPath.js
+++ b/src/processPath.js
@@ -15,7 +15,8 @@ module.exports = async ({
   defaultLanguage,
   defaultProvider,
   defaultCustomPrompt,
-  defaultIncludeSubdirectories
+  defaultIncludeSubdirectories,
+  defaultConvertBinary
 }) => {
   try {
     const provider = defaultProvider || 'ollama'
@@ -59,6 +60,9 @@ module.exports = async ({
       console.log(`⚪ Custom Prompt: ${customPrompt}`)
     }
 
+    const convertBinary = Boolean(defaultConvertBinary)
+    console.log(`⚪ Convert legacy Office binaries: ${convertBinary}`)
+
     console.log('--------------------------------------------------')
 
     const stats = await fs.stat(inputPath)
@@ -73,7 +77,8 @@ module.exports = async ({
       provider,
       inputPath,
       includeSubdirectories,
-      customPrompt
+      customPrompt,
+      convertBinary
     }
 
     if (stats.isDirectory()) {

--- a/src/readFileContent.js
+++ b/src/readFileContent.js
@@ -1,22 +1,483 @@
 const path = require('path')
+const { promises: fs } = require('fs')
+const { inflateRawSync } = require('zlib')
 const pdf = require('pdf-parse')
-const fs = require('fs').promises
 
-module.exports = async ({ filePath }) => {
-  try {
-    const ext = path.extname(filePath).toLowerCase()
+const { convertBinaryOfficeToDocx } = require('./binaryOfficeConversion')
 
-    let content = ''
-    if (ext === '.pdf') {
-      const dataBuffer = await fs.readFile(filePath)
-      const pdfData = await pdf(dataBuffer)
-      content = pdfData.text.trim()
-    } else {
-      content = fs.readFile(filePath, 'utf8')
+const DOCX_LIKE_EXTENSIONS = new Set(['.docx', '.docm', '.dotx', '.dotm'])
+const PPTX_LIKE_EXTENSIONS = new Set(['.pptx', '.pptm', '.ppsx', '.ppsm', '.potx', '.potm'])
+const XLSX_LIKE_EXTENSIONS = new Set(['.xlsx', '.xlsm', '.xlsb', '.xltx', '.xltm'])
+const BINARY_OFFICE_WARNINGS = {
+  '.doc': 'The .doc format is not supported for text extraction. Please convert the file to .docx or run with --convertbinary.',
+  '.dot': 'The .dot template format is not supported for text extraction. Please convert the file to .dotx or run with --convertbinary.',
+  '.ppt': 'The .ppt format is not supported for text extraction. Please convert the file to .pptx or run with --convertbinary.',
+  '.pps': 'The .pps format is not supported for text extraction. Please convert the file to .ppsx or run with --convertbinary.',
+  '.pot': 'The .pot template format is not supported for text extraction. Please convert the file to .potx or run with --convertbinary.',
+  '.xls': 'The .xls format is not supported for text extraction. Please convert the file to .xlsx or run with --convertbinary.',
+  '.xlt': 'The .xlt template format is not supported for text extraction. Please convert the file to .xltx or run with --convertbinary.'
+}
+
+const OPEN_DOCUMENT_TEXT_EXTENSIONS = new Set(['.odt'])
+const OPEN_DOCUMENT_PRESENTATION_EXTENSIONS = new Set(['.odp'])
+const OPEN_DOCUMENT_SPREADSHEET_EXTENSIONS = new Set(['.ods'])
+const KEYNOTE_EXTENSIONS = new Set(['.key'])
+
+const EOCD_SIGNATURE = 0x06054b50
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50
+
+const decodeXmlEntities = (input) => {
+  if (!input) return ''
+  return input
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+      const codePoint = parseInt(hex, 16)
+      return Number.isNaN(codePoint) ? '' : String.fromCodePoint(codePoint)
+    })
+    .replace(/&#([0-9]+);/g, (_, dec) => {
+      const codePoint = parseInt(dec, 10)
+      return Number.isNaN(codePoint) ? '' : String.fromCodePoint(codePoint)
+    })
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+const normalizeWhitespace = (text) => {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/[\t ]+/g, ' ').trim())
+    .filter(Boolean)
+    .join('\n')
+}
+
+const parseZipEntries = (buffer) => {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error('Expected a buffer when parsing a zip archive')
+  }
+
+  let eocdOffset = -1
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === EOCD_SIGNATURE) {
+      eocdOffset = i
+      break
+    }
+  }
+
+  if (eocdOffset === -1) {
+    throw new Error('Invalid archive: End of central directory record not found')
+  }
+
+  const centralDirectoryOffset = buffer.readUInt32LE(eocdOffset + 16)
+  const totalEntries = buffer.readUInt16LE(eocdOffset + 10)
+
+  const entries = new Map()
+  let offset = centralDirectoryOffset
+
+  for (let i = 0; i < totalEntries; i++) {
+    const signature = buffer.readUInt32LE(offset)
+    if (signature !== CENTRAL_DIRECTORY_SIGNATURE) {
+      break
     }
 
-    return content
-  } catch (err) {
-    throw new Error(err.message)
+    const compressionMethod = buffer.readUInt16LE(offset + 10)
+    const compressedSize = buffer.readUInt32LE(offset + 20)
+    const fileNameLength = buffer.readUInt16LE(offset + 28)
+    const extraFieldLength = buffer.readUInt16LE(offset + 30)
+    const commentLength = buffer.readUInt16LE(offset + 32)
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42)
+
+    const nameStart = offset + 46
+    const fileName = buffer.slice(nameStart, nameStart + fileNameLength).toString('utf8')
+
+    const localHeaderSignature = buffer.readUInt32LE(localHeaderOffset)
+    if (localHeaderSignature !== LOCAL_FILE_HEADER_SIGNATURE) {
+      offset = nameStart + fileNameLength + extraFieldLength + commentLength
+      continue
+    }
+
+    const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26)
+    const localExtraFieldLength = buffer.readUInt16LE(localHeaderOffset + 28)
+    const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength
+    const dataEnd = dataStart + compressedSize
+    const fileData = buffer.slice(dataStart, dataEnd)
+
+    let decompressed
+    if (compressionMethod === 0) {
+      decompressed = fileData
+    } else if (compressionMethod === 8) {
+      decompressed = inflateRawSync(fileData)
+    } else {
+      throw new Error(`Unsupported compression method ${compressionMethod} encountered in archive`)
+    }
+
+    entries.set(fileName, decompressed)
+
+    offset = nameStart + fileNameLength + extraFieldLength + commentLength
   }
+
+  return entries
+}
+
+const extractDocxText = (entries) => {
+  const relevantFiles = Array.from(entries.keys()).filter((file) => {
+    if (!file.startsWith('word/') || !file.endsWith('.xml')) return false
+    return /document|header|footer|footnotes|endnotes/i.test(file)
+  }).sort()
+
+  const paragraphs = []
+  const paragraphRegex = /<w:p[\s\S]*?<\/w:p>/g
+
+  const extractParagraphText = (paragraphXml) => {
+    const tokensRegex = /(<w:t[^>]*>[\s\S]*?<\/w:t>)|(<w:tab[^>]*\/>)+|(<w:br[^>]*\/>)|(<w:cr[^>]*\/>)|(<w:pBreak[^>]*\/>)|(<w:tbl>[\s\S]*?<\/w:tbl>)/g
+    tokensRegex.lastIndex = 0
+    const tokens = []
+    let match
+
+    while ((match = tokensRegex.exec(paragraphXml)) !== null) {
+      const [token] = match
+      if (token.startsWith('<w:t')) {
+        const text = token.replace(/<w:t[^>]*>/, '').replace(/<\/w:t>/, '')
+        tokens.push(decodeXmlEntities(text))
+      } else if (token.startsWith('<w:tab')) {
+        const tabCount = (token.match(/<w:tab[^>]*\/>/g) || ['']).length
+        tokens.push('\t'.repeat(tabCount))
+      } else if (token.startsWith('<w:tbl')) {
+        const cellText = token
+          .replace(/<w:tr[^>]*>/g, '\n')
+          .replace(/<\/w:tr>/g, '\n')
+          .replace(/<w:tc[^>]*>/g, '\t')
+          .replace(/<\/w:tc>/g, '\t')
+        const stripped = cellText.replace(/<[^>]+>/g, '')
+        tokens.push(decodeXmlEntities(stripped))
+      } else {
+        tokens.push('\n')
+      }
+    }
+
+    const combined = tokens.join('')
+    const lines = combined.split('\n')
+      .map((line) => line.replace(/[\t ]+/g, ' ').trim())
+      .filter(Boolean)
+    return lines.join('\n')
+  }
+
+  for (const file of relevantFiles) {
+    const xml = entries.get(file).toString('utf8')
+    paragraphRegex.lastIndex = 0
+    let match
+    while ((match = paragraphRegex.exec(xml)) !== null) {
+      const paragraphText = extractParagraphText(match[0])
+      if (paragraphText) {
+        paragraphs.push(paragraphText)
+      }
+    }
+  }
+
+  return paragraphs.join('\n\n').trim()
+}
+
+const naturalCompare = (a, b) => {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+const extractPptxText = (entries) => {
+  const slideFiles = Array.from(entries.keys())
+    .filter((file) => /^ppt\/slides\/slide[0-9]+\.xml$/i.test(file))
+    .sort(naturalCompare)
+
+  const slides = []
+  for (const file of slideFiles) {
+    const xml = entries.get(file).toString('utf8')
+      .replace(/<a:br[^>]*\/>/g, '\n')
+      .replace(/<a:tab[^>]*\/>/g, '\t')
+
+    const textSegments = []
+    const textRegex = /<a:t[^>]*>([\s\S]*?)<\/a:t>/g
+    let match
+    while ((match = textRegex.exec(xml)) !== null) {
+      const segment = decodeXmlEntities(match[1])
+      const cleaned = segment.split('\n').map((line) => line.replace(/[\t ]+/g, ' ').trim()).filter(Boolean).join('\n')
+      if (cleaned) {
+        textSegments.push(cleaned)
+      }
+    }
+
+    const slideText = textSegments.join('\n')
+    if (slideText) {
+      slides.push(slideText)
+    }
+  }
+
+  return slides.join('\n\n').trim()
+}
+
+const extractKeynoteText = (entries) => {
+  let keynoteFile = null
+  for (const candidate of ['index.apxl', 'Index.apxl']) {
+    if (entries.has(candidate)) {
+      keynoteFile = entries.get(candidate)
+      break
+    }
+  }
+
+  if (!keynoteFile) return ''
+
+  const xml = keynoteFile.toString('utf8')
+    .replace(/<sf:tab[^>]*\/>/g, '\t')
+    .replace(/<sf:lineBreak[^>]*\/>/g, '\n')
+
+  const text = xml.replace(/<[^>]+>/g, ' ')
+  return normalizeWhitespace(decodeXmlEntities(text))
+}
+
+const extractSharedStrings = (entries) => {
+  const sharedStrings = []
+  if (!entries.has('xl/sharedStrings.xml')) return sharedStrings
+
+  const xml = entries.get('xl/sharedStrings.xml').toString('utf8')
+  const stringRegex = /<si[^>]*>([\s\S]*?)<\/si>/g
+  let match
+  while ((match = stringRegex.exec(xml)) !== null) {
+    const segment = match[1]
+    const textPieces = []
+    const textRegex = /<t[^>]*>([\s\S]*?)<\/t>/g
+    let textMatch
+    while ((textMatch = textRegex.exec(segment)) !== null) {
+      textPieces.push(decodeXmlEntities(textMatch[1]))
+    }
+    const combined = textPieces.join('')
+    sharedStrings.push(combined)
+  }
+
+  return sharedStrings
+}
+
+const buildSheetNameMap = (entries) => {
+  const sheetNameByRelId = new Map()
+  const sheetTargets = new Map()
+
+  if (entries.has('xl/workbook.xml')) {
+    const workbookXml = entries.get('xl/workbook.xml').toString('utf8')
+    const sheetRegex = /<sheet[^>]*name="([^"]+)"[^>]*r:id="([^"]+)"[^>]*>/g
+    let match
+    while ((match = sheetRegex.exec(workbookXml)) !== null) {
+      const [, name, relId] = match
+      sheetNameByRelId.set(relId, decodeXmlEntities(name))
+    }
+  }
+
+  if (entries.has('xl/_rels/workbook.xml.rels')) {
+    const relsXml = entries.get('xl/_rels/workbook.xml.rels').toString('utf8')
+    const relRegex = /<Relationship[^>]*Id="([^"]+)"[^>]*Target="([^"]+)"/g
+    let match
+    while ((match = relRegex.exec(relsXml)) !== null) {
+      const [, relId, target] = match
+      const sheetName = sheetNameByRelId.get(relId)
+      if (!sheetName) continue
+
+      let normalizedTarget = target
+      if (!normalizedTarget.startsWith('/')) {
+        normalizedTarget = `xl/${normalizedTarget.replace(/^\.\//, '')}`
+      } else {
+        normalizedTarget = `xl${normalizedTarget}`
+      }
+      sheetTargets.set(normalizedTarget, sheetName)
+    }
+  }
+
+  return sheetTargets
+}
+
+const extractSheetText = (xml, sharedStrings) => {
+  const rows = []
+  const rowRegex = /<row[^>]*>([\s\S]*?)<\/row>/g
+  let rowMatch
+
+  while ((rowMatch = rowRegex.exec(xml)) !== null) {
+    const rowCells = []
+    const cellRegex = /<c([^>]*)>([\s\S]*?)<\/c>/g
+    let cellMatch
+    while ((cellMatch = cellRegex.exec(rowMatch[1])) !== null) {
+      const [, rawAttributes, cellBody] = cellMatch
+      const typeMatch = /t="([^"]+)"/.exec(rawAttributes)
+      let cellValue = ''
+
+      if (typeMatch && typeMatch[1] === 's') {
+        const valueMatch = /<v>([\s\S]*?)<\/v>/.exec(cellBody)
+        if (valueMatch) {
+          const index = parseInt(valueMatch[1], 10)
+          if (!Number.isNaN(index) && sharedStrings[index]) {
+            cellValue = sharedStrings[index]
+          }
+        }
+      } else if (typeMatch && typeMatch[1] === 'inlineStr') {
+        const inlinePieces = []
+        const inlineRegex = /<t[^>]*>([\s\S]*?)<\/t>/g
+        let inlineMatch
+        while ((inlineMatch = inlineRegex.exec(cellBody)) !== null) {
+          inlinePieces.push(decodeXmlEntities(inlineMatch[1]))
+        }
+        cellValue = inlinePieces.join('')
+      } else {
+        const valueMatch = /<v>([\s\S]*?)<\/v>/.exec(cellBody)
+        if (valueMatch) {
+          cellValue = decodeXmlEntities(valueMatch[1])
+        }
+      }
+
+      if (!cellValue) {
+        const textMatch = /<t[^>]*>([\s\S]*?)<\/t>/.exec(cellBody)
+        if (textMatch) {
+          cellValue = decodeXmlEntities(textMatch[1])
+        }
+      }
+
+      rowCells.push(cellValue.replace(/[\t ]+/g, ' ').trim())
+    }
+
+    if (rowCells.some((cell) => cell.length > 0)) {
+      rows.push(rowCells)
+    }
+  }
+
+  const lines = rows.map((cells) => cells.join('\t').trim()).filter(Boolean)
+  return lines.join('\n')
+}
+
+const extractXlsxText = (entries) => {
+  const sharedStrings = extractSharedStrings(entries)
+  const sheetNames = buildSheetNameMap(entries)
+
+  const sheetFiles = Array.from(entries.keys())
+    .filter((file) => /^xl\/worksheets\/[\w-]+\.xml$/i.test(file))
+    .sort(naturalCompare)
+
+  const sheets = []
+  for (const file of sheetFiles) {
+    const sheetXml = entries.get(file).toString('utf8')
+    const sheetText = extractSheetText(sheetXml, sharedStrings)
+    if (sheetText) {
+      const displayName = sheetNames.get(file) || file.replace(/^xl\/worksheets\//, '').replace(/\.xml$/i, '')
+      sheets.push(`Sheet: ${displayName}\n${sheetText}`)
+    }
+  }
+
+  return sheets.join('\n\n').trim()
+}
+
+const extractOpenDocumentText = (entries) => {
+  if (!entries.has('content.xml')) return ''
+  const xml = entries.get('content.xml').toString('utf8')
+    .replace(/<text:line-break\s*\/>/g, '\n')
+    .replace(/<text:tab\s*\/>/g, '\t')
+    .replace(/<draw:frame[^>]*>/g, '\n')
+    .replace(/<\/draw:frame>/g, '\n')
+
+  const stripped = xml.replace(/<[^>]+>/g, ' ')
+  return normalizeWhitespace(decodeXmlEntities(stripped))
+}
+
+const readPdf = async (filePath) => {
+  const dataBuffer = await fs.readFile(filePath)
+  const pdfData = await pdf(dataBuffer)
+  return pdfData.text.trim()
+}
+
+const readDocxLike = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractDocxText(entries)
+}
+
+const readPptxLike = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractPptxText(entries)
+}
+
+const readKeynote = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractKeynoteText(entries)
+}
+
+const readXlsxLike = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractXlsxText(entries)
+}
+
+const readOpenDocument = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractOpenDocumentText(entries)
+}
+
+const readRtf = async (filePath) => {
+  const raw = await fs.readFile(filePath, 'utf8')
+
+  const normalized = raw
+    .replace(/\\'([0-9a-fA-F]{2})/g, (_, hex) => {
+      const codePoint = parseInt(hex, 16)
+      return Number.isNaN(codePoint) ? '' : String.fromCharCode(codePoint)
+    })
+    .replace(/\\par[d]?/g, '\n')
+    .replace(/\\tab/g, '\t')
+    .replace(/\\line/g, '\n')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\~|\\-/g, ' ')
+    .replace(/\\[^\s]+ ?/g, '')
+    .replace(/[{}]/g, '')
+
+  return normalizeWhitespace(normalized)
+}
+
+module.exports = async ({ filePath, convertBinary = false }) => {
+  const ext = path.extname(filePath).toLowerCase()
+
+  if (ext === '.pdf') {
+    return readPdf(filePath)
+  }
+
+  if (DOCX_LIKE_EXTENSIONS.has(ext)) {
+    return readDocxLike(filePath)
+  }
+
+  if (PPTX_LIKE_EXTENSIONS.has(ext)) {
+    return readPptxLike(filePath)
+  }
+
+  if (XLSX_LIKE_EXTENSIONS.has(ext)) {
+    return readXlsxLike(filePath)
+  }
+
+  if (KEYNOTE_EXTENSIONS.has(ext)) {
+    return readKeynote(filePath)
+  }
+
+  if (OPEN_DOCUMENT_TEXT_EXTENSIONS.has(ext) || OPEN_DOCUMENT_PRESENTATION_EXTENSIONS.has(ext) || OPEN_DOCUMENT_SPREADSHEET_EXTENSIONS.has(ext)) {
+    return readOpenDocument(filePath)
+  }
+
+  if (ext === '.rtf') {
+    return readRtf(filePath)
+  }
+
+  if (BINARY_OFFICE_WARNINGS[ext]) {
+    if (convertBinary) {
+      const { tempPath, cleanup } = await convertBinaryOfficeToDocx({ filePath, ext })
+      try {
+        return await readDocxLike(tempPath)
+      } finally {
+        await cleanup()
+      }
+    }
+    throw new Error(BINARY_OFFICE_WARNINGS[ext])
+  }
+
+  const content = await fs.readFile(filePath, 'utf8')
+  return typeof content === 'string' ? content : content.toString('utf8')
 }

--- a/src/supportedExtensions.js
+++ b/src/supportedExtensions.js
@@ -26,6 +26,15 @@ module.exports = [
   // other
   '.txt', '.log', '.diff', '.patch', '.proto', '.tex',
 
+  // office documents
+  '.doc', '.docx', '.docm', '.dot', '.dotx', '.dotm', '.rtf', '.odt',
+
+  // office presentations
+  '.ppt', '.pptx', '.pptm', '.pps', '.ppsx', '.ppsm', '.pot', '.potx', '.potm', '.key', '.odp',
+
+  // office spreadsheets
+  '.xls', '.xlsx', '.xlsm', '.xlsb', '.xlt', '.xltx', '.xltm', '.ods',
+
   // image files
   '.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff',
 


### PR DESCRIPTION
## Summary
- add a pure Node converter that extracts text from legacy Office binaries and writes a temporary OOXML document for downstream parsing
- update the file reader to use the new converter when --convertbinary is enabled so LibreOffice is no longer required

## Testing
- npx standard

------
https://chatgpt.com/codex/tasks/task_e_68cdb7d76578833091b15c74a73a3b0e