### PR TITLE
Limit prompt size and add metadata hints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 .DS_Store
 *.sublime-*
 *.code-workspace
+*.log

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ai-renamer",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ai-renamer",
-      "version": "1.0.23",
+      "version": "1.0.24",
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^1.7.2",

--- a/src/binaryOfficeConversion.js
+++ b/src/binaryOfficeConversion.js
@@ -1,0 +1,519 @@
+const path = require('path')
+const os = require('os')
+const { promises: fs } = require('fs')
+const { execFile } = require('child_process')
+const { promisify } = require('util')
+
+const execFileAsync = promisify(execFile)
+
+const EOCD_SIGNATURE = 0x06054b50
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50
+
+const MIN_LINE_LENGTH = 3
+
+const BINARY_OFFICE_KINDS = {
+  '.doc': 'word',
+  '.dot': 'word',
+  '.ppt': 'presentation',
+  '.pps': 'presentation',
+  '.pot': 'presentation',
+  '.xls': 'spreadsheet',
+  '.xlt': 'spreadsheet'
+}
+
+const ALLOWED_LIBRARY_EXTENSIONS = new Set(['.docx', '.dotx'])
+
+const logVerbose = (verbose, message) => {
+  if (!verbose) return
+  console.log(message)
+}
+
+const escapeXml = (input) => {
+  if (!input) return ''
+  return input
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;')
+}
+
+const toDosDateTime = (date) => {
+  const year = Math.max(1980, date.getFullYear())
+  const dosDate = ((year - 1980) << 9) | ((date.getMonth() + 1) << 5) | date.getDate()
+  const dosTime = (date.getHours() << 11) | (date.getMinutes() << 5) | Math.floor(date.getSeconds() / 2)
+  return { dosDate, dosTime }
+}
+
+const crc32Table = new Uint32Array(256).map((_, index) => {
+  let c = index
+  for (let k = 0; k < 8; k++) {
+    if (c & 1) {
+      c = 0xedb88320 ^ (c >>> 1)
+    } else {
+      c >>>= 1
+    }
+  }
+  return c >>> 0
+})
+
+const crc32 = (buffer) => {
+  let crc = 0 ^ 0xffffffff
+  for (let i = 0; i < buffer.length; i++) {
+    const byte = buffer[i]
+    crc = crc32Table[(crc ^ byte) & 0xff] ^ (crc >>> 8)
+  }
+  return (crc ^ 0xffffffff) >>> 0
+}
+
+const createStoredZip = (files) => {
+  const localParts = []
+  const centralParts = []
+  let offset = 0
+  const now = new Date()
+  const { dosDate, dosTime } = toDosDateTime(now)
+
+  for (const file of files) {
+    const nameBuffer = Buffer.from(file.name, 'utf8')
+    const dataBuffer = Buffer.isBuffer(file.data) ? file.data : Buffer.from(file.data, 'utf8')
+    const crc = crc32(dataBuffer)
+
+    const localHeader = Buffer.alloc(30)
+    localHeader.writeUInt32LE(LOCAL_FILE_HEADER_SIGNATURE, 0)
+    localHeader.writeUInt16LE(20, 4)
+    localHeader.writeUInt16LE(0, 6)
+    localHeader.writeUInt16LE(0, 8)
+    localHeader.writeUInt16LE(dosTime, 10)
+    localHeader.writeUInt16LE(dosDate, 12)
+    localHeader.writeUInt32LE(crc, 14)
+    localHeader.writeUInt32LE(dataBuffer.length, 18)
+    localHeader.writeUInt32LE(dataBuffer.length, 22)
+    localHeader.writeUInt16LE(nameBuffer.length, 26)
+    localHeader.writeUInt16LE(0, 28)
+
+    const localEntry = Buffer.concat([localHeader, nameBuffer, dataBuffer])
+    localParts.push(localEntry)
+
+    const centralHeader = Buffer.alloc(46)
+    centralHeader.writeUInt32LE(CENTRAL_DIRECTORY_SIGNATURE, 0)
+    centralHeader.writeUInt16LE(0x0314, 4)
+    centralHeader.writeUInt16LE(20, 6)
+    centralHeader.writeUInt16LE(0, 8)
+    centralHeader.writeUInt16LE(0, 10)
+    centralHeader.writeUInt16LE(dosTime, 12)
+    centralHeader.writeUInt16LE(dosDate, 14)
+    centralHeader.writeUInt32LE(crc, 16)
+    centralHeader.writeUInt32LE(dataBuffer.length, 20)
+    centralHeader.writeUInt32LE(dataBuffer.length, 24)
+    centralHeader.writeUInt16LE(nameBuffer.length, 28)
+    centralHeader.writeUInt16LE(0, 30)
+    centralHeader.writeUInt16LE(0, 32)
+    centralHeader.writeUInt16LE(0, 34)
+    centralHeader.writeUInt16LE(0, 36)
+    centralHeader.writeUInt32LE(0, 38)
+    centralHeader.writeUInt32LE(offset, 42)
+
+    const centralEntry = Buffer.concat([centralHeader, nameBuffer])
+    centralParts.push(centralEntry)
+
+    offset += localEntry.length
+  }
+
+  const localSection = Buffer.concat(localParts)
+  const centralSection = Buffer.concat(centralParts)
+
+  const eocd = Buffer.alloc(22)
+  eocd.writeUInt32LE(EOCD_SIGNATURE, 0)
+  eocd.writeUInt16LE(0, 4)
+  eocd.writeUInt16LE(0, 6)
+  eocd.writeUInt16LE(files.length, 8)
+  eocd.writeUInt16LE(files.length, 10)
+  eocd.writeUInt32LE(centralSection.length, 12)
+  eocd.writeUInt32LE(localSection.length, 16)
+  eocd.writeUInt16LE(0, 20)
+
+  return Buffer.concat([localSection, centralSection, eocd])
+}
+
+const collectSegments = (text, matchRegex, stripRegex) => {
+  if (!text) return []
+  const matches = text.match(matchRegex) || []
+  const results = []
+  for (const match of matches) {
+    const cleaned = match
+      .replace(stripRegex, ' ')
+      .replace(/\r\n?/g, '\n')
+      .split('\n')
+      .map((line) => line.replace(/\s+/g, ' ').trim())
+      .filter(Boolean)
+    results.push(...cleaned)
+  }
+  return results
+}
+
+const extractBinaryLines = (buffer) => {
+  const lines = []
+  const seen = new Set()
+
+  const pushLines = (candidates) => {
+    for (const candidate of candidates) {
+      if (!candidate || candidate.length < MIN_LINE_LENGTH) continue
+      if (seen.has(candidate)) continue
+      seen.add(candidate)
+      lines.push(candidate)
+    }
+  }
+
+  const asciiText = buffer.toString('latin1')
+  pushLines(collectSegments(asciiText, /[\x20-\x7E\s]{4,}/g, /[^\x20-\x7E\s]/g))
+
+  const unicodeText = buffer.toString('utf16le')
+  pushLines(collectSegments(unicodeText, /[\u0020-\uD7FF\uE000-\uFFFD\s]{4,}/g, /[^\u0020-\uD7FF\uE000-\uFFFD\s]/g))
+
+  const utf8Text = buffer.toString('utf8')
+  pushLines(collectSegments(utf8Text, /[\u0020-\uD7FF\uE000-\uFFFD\s]{4,}/g, /[^\u0020-\uD7FF\uE000-\uFFFD\s]/g))
+
+  return lines
+}
+
+const buildDocxBuffer = (lines) => {
+  const paragraphs = lines.length > 0 ? lines : ['Converted legacy Office document']
+  const bodyContent = paragraphs.map((line) => {
+    return `<w:p><w:r><w:t xml:space="preserve">${escapeXml(line)}</w:t></w:r></w:p>`
+  }).join('')
+
+  const documentXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <w:body>${bodyContent}<w:sectPr><w:pgSz w:w="12240" w:h="15840"/><w:pgMar w:top="1440" w:right="1440" w:bottom="1440" w:left="1440" w:header="720" w:footer="720" w:gutter="0"/></w:sectPr></w:body>
+</w:document>`
+
+  const contentTypesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/>
+  <Override PartName="/word/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.styles+xml"/>
+</Types>`
+
+  const packageRelsXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/>
+</Relationships>`
+
+  const stylesXml = `<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<w:styles xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
+  <w:style w:type="paragraph" w:default="1" w:styleId="Normal"><w:name w:val="Normal"/><w:qFormat/></w:style>
+</w:styles>`
+
+  const files = [
+    { name: '[Content_Types].xml', data: Buffer.from(contentTypesXml, 'utf8') },
+    { name: '_rels/.rels', data: Buffer.from(packageRelsXml, 'utf8') },
+    { name: 'word/document.xml', data: Buffer.from(documentXml, 'utf8') },
+    { name: 'word/styles.xml', data: Buffer.from(stylesXml, 'utf8') }
+  ]
+
+  return createStoredZip(files)
+}
+
+const isInsideDirectory = (directory, target) => {
+  if (!directory) return false
+  const relative = path.relative(directory, target)
+  return relative === '' || (!relative.startsWith('..') && !path.isAbsolute(relative))
+}
+
+let doc2docxLoader
+
+const loadDoc2Docx = async () => {
+  if (doc2docxLoader === undefined) {
+    doc2docxLoader = import('doc2docx')
+      .then((mod) => mod?.default ?? mod)
+      .catch(() => null)
+  }
+  return doc2docxLoader
+}
+
+const fileExists = async (filePath) => {
+  try {
+    await fs.access(filePath)
+    return true
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) return false
+    throw err
+  }
+}
+
+const findConvertedFile = async ({ dir, baseName, extensions }) => {
+  try {
+    const entries = await fs.readdir(dir)
+    const normalizedBase = baseName.toLowerCase()
+    const candidates = entries
+      .filter((entry) => extensions.has(path.extname(entry).toLowerCase()))
+      .map((entry) => ({
+        entry,
+        exact: path.basename(entry, path.extname(entry)).toLowerCase() === normalizedBase
+      }))
+
+    if (candidates.length === 0) return null
+    const match = candidates.find((candidate) => candidate.exact) || candidates[0]
+    return path.join(dir, match.entry)
+  } catch (err) {
+    if (err && (err.code === 'ENOENT' || err.code === 'ENOTDIR')) return null
+    throw err
+  }
+}
+
+const ensureOutputPath = async ({
+  searchDirs,
+  outputPath,
+  baseName,
+  verbose,
+  workspaceDir,
+  originalDocxInfo
+}) => {
+  for (const dir of searchDirs) {
+    const candidate = await findConvertedFile({ dir, baseName, extensions: ALLOWED_LIBRARY_EXTENSIONS })
+    if (!candidate) continue
+
+    if (candidate !== outputPath) {
+      await fs.copyFile(candidate, outputPath)
+      const shouldRemove = isInsideDirectory(workspaceDir, candidate) || (
+        originalDocxInfo &&
+        candidate === originalDocxInfo.path &&
+        !originalDocxInfo.existed
+      )
+
+      if (shouldRemove) {
+        await fs.rm(candidate, { force: true })
+        logVerbose(verbose, `🧽 Removed intermediate converted file at ${candidate}`)
+      }
+    }
+
+    return true
+  }
+
+  return false
+}
+
+const runDoc2DocxFunction = async ({
+  fn,
+  inputPath,
+  outputPath,
+  baseName,
+  searchDirs,
+  workspaceDir,
+  originalDocxInfo,
+  verbose
+}) => {
+  const signatures = [
+    () => fn(inputPath, outputPath),
+    () => fn({ input: inputPath, output: outputPath }),
+    () => fn({ source: inputPath, destination: outputPath }),
+    () => fn(inputPath)
+  ]
+
+  for (const invoke of signatures) {
+    try {
+      const result = invoke()
+      if (result && typeof result.then === 'function') await result
+      const resolved = await ensureOutputPath({
+        searchDirs,
+        outputPath,
+        baseName,
+        verbose,
+        workspaceDir,
+        originalDocxInfo
+      })
+      if (resolved) return true
+    } catch (err) {
+      logVerbose(verbose, `⚠️ doc2docx invocation failed: ${err.message}`)
+    }
+  }
+
+  return false
+}
+
+const convertUsingModule = async ({
+  module,
+  inputPath,
+  outputPath,
+  baseName,
+  workspaceDir,
+  originalDocxInfo,
+  verbose
+}) => {
+  if (!module) return false
+
+  const searchDirs = [path.dirname(outputPath), path.dirname(inputPath)]
+  const candidates = []
+  if (typeof module === 'function') candidates.push(module)
+  if (module && typeof module.convert === 'function') candidates.push(module.convert.bind(module))
+  if (module && typeof module.default === 'function') candidates.push(module.default.bind(module))
+  if (module && typeof module.doc2docx === 'function') candidates.push(module.doc2docx.bind(module))
+
+  for (const fn of candidates) {
+    const success = await runDoc2DocxFunction({
+      fn,
+      inputPath,
+      outputPath,
+      baseName,
+      searchDirs,
+      workspaceDir,
+      originalDocxInfo,
+      verbose
+    })
+    if (success) return true
+  }
+
+  return false
+}
+
+const convertUsingCli = async ({
+  filePath,
+  tempDir,
+  outputPath,
+  baseName,
+  originalDocxInfo,
+  verbose
+}) => {
+  const inputCopyPath = path.join(tempDir, path.basename(filePath))
+  try {
+    await fs.copyFile(filePath, inputCopyPath)
+  } catch (err) {
+    logVerbose(verbose, `⚠️ Unable to prepare temporary input for doc2docx CLI: ${err.message}`)
+    return false
+  }
+
+  const inputName = path.basename(inputCopyPath)
+  const outputName = path.basename(outputPath)
+  const attempts = [
+    [inputCopyPath, outputPath],
+    [inputCopyPath],
+    [inputName],
+    [inputName, outputName],
+    ['--output', outputPath, inputCopyPath],
+    ['--output', outputName, inputName],
+    [inputCopyPath, '--output', outputPath],
+    [inputName, '--output', outputName],
+    ['--input', inputCopyPath, '--output', outputPath]
+  ]
+
+  const attempted = new Set()
+  let conversionSucceeded = false
+
+  for (const args of attempts) {
+    const key = args.join('|')
+    if (attempted.has(key)) continue
+    attempted.add(key)
+
+    try {
+      await execFileAsync('doc2docx', args, { cwd: tempDir })
+      const resolved = await ensureOutputPath({
+        searchDirs: [tempDir],
+        outputPath,
+        baseName,
+        verbose,
+        workspaceDir: tempDir,
+        originalDocxInfo
+      })
+      if (resolved) {
+        conversionSucceeded = true
+        break
+      }
+    } catch (err) {
+      logVerbose(verbose, `⚠️ doc2docx CLI attempt failed (${args.join(' ')}): ${err.message}`)
+    }
+  }
+
+  try {
+    await fs.rm(inputCopyPath, { force: true })
+  } catch (err) {
+    logVerbose(verbose, `⚠️ Failed to remove temporary copy ${inputCopyPath}: ${err.message}`)
+  }
+
+  return conversionSucceeded
+}
+
+const convertBinaryOfficeToDocx = async ({ filePath, ext, verbose = false }) => {
+  const kind = BINARY_OFFICE_KINDS[ext]
+  if (!kind) {
+    throw new Error(`Unsupported binary Office extension: ${ext}`)
+  }
+
+  const baseName = path.basename(filePath, ext) || 'converted'
+  const originalDocxPath = path.join(path.dirname(filePath), `${baseName}.docx`)
+  const originalDocxExists = await fileExists(originalDocxPath)
+  const originalDocxInfo = { path: originalDocxPath, existed: originalDocxExists }
+
+  logVerbose(verbose, `⚙️ Starting legacy ${kind} conversion for ${path.basename(filePath)}`)
+
+  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'ai-renamer-legacy-'))
+  let cleaned = false
+  const cleanup = async () => {
+    if (cleaned) return
+    cleaned = true
+    await fs.rm(tempDir, { recursive: true, force: true })
+    logVerbose(verbose, `🧹 Removed temporary directory ${tempDir}`)
+  }
+
+  const tempPath = path.join(tempDir, `${baseName}.docx`)
+
+  if (kind === 'word') {
+    const module = await loadDoc2Docx()
+    if (module) {
+      logVerbose(verbose, '🔧 Attempting doc2docx module conversion')
+      const converted = await convertUsingModule({
+        module,
+        inputPath: filePath,
+        outputPath: tempPath,
+        baseName,
+        workspaceDir: tempDir,
+        originalDocxInfo,
+        verbose
+      })
+
+      if (converted) {
+        logVerbose(verbose, `✅ doc2docx module produced ${tempPath}`)
+        return { tempPath, cleanup }
+      }
+
+      logVerbose(verbose, '⚠️ doc2docx module did not produce a DOCX output, trying CLI fallback')
+    } else {
+      logVerbose(verbose, 'ℹ️ doc2docx module not available, attempting CLI conversion')
+    }
+
+    const cliConverted = await convertUsingCli({
+      filePath,
+      tempDir,
+      outputPath: tempPath,
+      baseName,
+      originalDocxInfo,
+      verbose
+    })
+
+    if (cliConverted) {
+      logVerbose(verbose, `✅ doc2docx CLI produced ${tempPath}`)
+      return { tempPath, cleanup }
+    }
+
+    logVerbose(verbose, '⚠️ doc2docx conversion attempts failed, reverting to text extraction fallback')
+  }
+
+  const buffer = await fs.readFile(filePath)
+  const lines = extractBinaryLines(buffer)
+
+  logVerbose(verbose, `🧵 Extracted ${lines.length} text segment(s) from binary ${kind} file`)
+
+  if (lines.length === 0) {
+    await cleanup()
+    throw new Error(`No textual content could be extracted from ${path.basename(filePath)}. The file may require manual conversion.`)
+  }
+
+  const docxBuffer = buildDocxBuffer(lines)
+  await fs.writeFile(tempPath, docxBuffer)
+  logVerbose(verbose, `📦 Wrote fallback DOCX to ${tempPath}`)
+
+  return { tempPath, cleanup }
+}
+
+module.exports = { convertBinaryOfficeToDocx }

--- a/src/configureYargs.js
+++ b/src/configureYargs.js
@@ -31,7 +31,11 @@ const loadConfig = async () => {
       defaultLog: normalizeBoolean(parsed.defaultLog),
       defaultIncludeSubdirectories: normalizeBoolean(parsed.defaultIncludeSubdirectories, false),
       defaultUseFilenameHint: normalizeBoolean(parsed.defaultUseFilenameHint, true),
-      defaultMetadataHints: normalizeBoolean(parsed.defaultMetadataHints, true)
+      defaultMetadataHints: normalizeBoolean(parsed.defaultMetadataHints, true),
+      defaultAppendTags: normalizeBoolean(parsed.defaultAppendTags, false),
+      defaultCompanyFocus: normalizeBoolean(parsed.defaultCompanyFocus, false),
+      defaultPeopleFocus: normalizeBoolean(parsed.defaultPeopleFocus, false),
+      defaultProjectFocus: normalizeBoolean(parsed.defaultProjectFocus, false)
     }
   } catch (err) {
     return {}
@@ -139,6 +143,26 @@ module.exports = async () => {
       type: 'boolean',
       description: 'Provide file metadata (dates, size) to the model when available',
       default: config.defaultMetadataHints !== undefined ? config.defaultMetadataHints : true
+    })
+    .option('append-tags', {
+      type: 'boolean',
+      description: 'Append macOS Finder tags to the generated filename before the date segment',
+      default: config.defaultAppendTags || false
+    })
+    .option('company-focus', {
+      type: 'boolean',
+      description: 'Bias the prompt to identify the company or organization first when building filenames',
+      default: config.defaultCompanyFocus || false
+    })
+    .option('people-focus', {
+      type: 'boolean',
+      description: 'Bias the prompt to identify people, teams, or committees first when building filenames',
+      default: config.defaultPeopleFocus || false
+    })
+    .option('project-focus', {
+      type: 'boolean',
+      description: 'Bias the prompt to identify projects or initiatives first when building filenames',
+      default: config.defaultProjectFocus || false
     }).argv
 
   if (argv.help) {
@@ -258,6 +282,42 @@ module.exports = async () => {
 
   if (metadataHintsProvided) {
     config.defaultMetadataHints = argv['metadata-hints']
+    await saveConfig({ config })
+  }
+
+  const appendTagsProvided = process.argv.some((arg) => {
+    return arg === '--append-tags' || arg === '--no-append-tags' || arg.startsWith('--append-tags=') || arg.startsWith('--no-append-tags=')
+  })
+
+  if (appendTagsProvided) {
+    config.defaultAppendTags = argv['append-tags']
+    await saveConfig({ config })
+  }
+
+  const companyFocusProvided = process.argv.some((arg) => {
+    return arg === '--company-focus' || arg === '--no-company-focus' || arg.startsWith('--company-focus=') || arg.startsWith('--no-company-focus=')
+  })
+
+  if (companyFocusProvided) {
+    config.defaultCompanyFocus = argv['company-focus']
+    await saveConfig({ config })
+  }
+
+  const peopleFocusProvided = process.argv.some((arg) => {
+    return arg === '--people-focus' || arg === '--no-people-focus' || arg.startsWith('--people-focus=') || arg.startsWith('--no-people-focus=')
+  })
+
+  if (peopleFocusProvided) {
+    config.defaultPeopleFocus = argv['people-focus']
+    await saveConfig({ config })
+  }
+
+  const projectFocusProvided = process.argv.some((arg) => {
+    return arg === '--project-focus' || arg === '--no-project-focus' || arg.startsWith('--project-focus=') || arg.startsWith('--no-project-focus=')
+  })
+
+  if (projectFocusProvided) {
+    config.defaultProjectFocus = argv['project-focus']
     await saveConfig({ config })
   }
 

--- a/src/configureYargs.js
+++ b/src/configureYargs.js
@@ -33,6 +33,7 @@ const loadConfig = async () => {
       defaultUseFilenameHint: normalizeBoolean(parsed.defaultUseFilenameHint, true),
       defaultMetadataHints: normalizeBoolean(parsed.defaultMetadataHints, true),
       defaultAppendTags: normalizeBoolean(parsed.defaultAppendTags, false),
+      defaultPitchDeckOnly: normalizeBoolean(parsed.defaultPitchDeckOnly, false),
       defaultCompanyFocus: normalizeBoolean(parsed.defaultCompanyFocus, false),
       defaultPeopleFocus: normalizeBoolean(parsed.defaultPeopleFocus, false),
       defaultProjectFocus: normalizeBoolean(parsed.defaultProjectFocus, false)
@@ -148,6 +149,11 @@ module.exports = async () => {
       type: 'boolean',
       description: 'Append macOS Finder tags to the generated filename before the date segment',
       default: config.defaultAppendTags || false
+    })
+    .option('pitch-deck-only', {
+      type: 'boolean',
+      description: 'Only rename PDFs detected as startup pitch decks using the dedicated filename template',
+      default: config.defaultPitchDeckOnly || false
     })
     .option('company-focus', {
       type: 'boolean',
@@ -291,6 +297,16 @@ module.exports = async () => {
 
   if (appendTagsProvided) {
     config.defaultAppendTags = argv['append-tags']
+    await saveConfig({ config })
+  }
+
+  const pitchDeckProvided = process.argv.some((arg) => {
+    return arg === '--pitch-deck-only' || arg === '--no-pitch-deck-only' ||
+      arg.startsWith('--pitch-deck-only=') || arg.startsWith('--no-pitch-deck-only=')
+  })
+
+  if (pitchDeckProvided) {
+    config.defaultPitchDeckOnly = argv['pitch-deck-only']
     await saveConfig({ config })
   }
 

--- a/src/detectPitchDeck.js
+++ b/src/detectPitchDeck.js
@@ -1,0 +1,199 @@
+const COMPANY_REGEX = /([A-Z][A-Za-z0-9&']+(?:\s+[A-Z][A-Za-z0-9&']+)*)\s+(?:Inc\.?|Incorporated|Corp\.?|Corporation|LLC|L\.L\.C\.|Ltd\.?|Limited|Company|Co\.?)/g
+
+const STRONG_KEYWORDS = [
+  'pitch deck',
+  'investor deck',
+  'investor presentation',
+  'fundraising deck',
+  'fund raising deck',
+  'fundraise deck'
+]
+
+const FUNDING_KEYWORDS = [
+  'seed round',
+  'pre-seed',
+  'series a',
+  'series b',
+  'series c',
+  'series d',
+  'series e',
+  'bridge round',
+  'angel round',
+  'vc round',
+  'funding round',
+  'capital raise',
+  'venture round'
+]
+
+const INVESTOR_KEYWORDS = [
+  'investor',
+  'investment',
+  'venture capital',
+  'vc',
+  'capital raise',
+  'fundraising',
+  'fund raising',
+  'term sheet'
+]
+
+const SECTION_KEYWORDS = [
+  'problem',
+  'solution',
+  'market',
+  'market size',
+  'market opportunity',
+  'product',
+  'business model',
+  'traction',
+  'financials',
+  'financial projections',
+  'go-to-market',
+  'go to market',
+  'competitive landscape',
+  'competition',
+  'team',
+  'roadmap',
+  'use of funds',
+  'funds use',
+  'revenue',
+  'milestones',
+  'ask',
+  'summary'
+]
+
+const normalize = value => {
+  if (!value) return ''
+  return value.toString().toLowerCase()
+}
+
+const collectMatches = (text, keywords) => {
+  const matches = []
+  for (const keyword of keywords) {
+    if (text.includes(keyword)) {
+      matches.push(keyword)
+    }
+  }
+  return matches
+}
+
+const extractCompanyCandidates = lines => {
+  const candidates = []
+  const seen = new Set()
+
+  const consider = value => {
+    if (!value) return
+    const trimmed = value.trim()
+    if (!trimmed || trimmed.length < 3) return
+    const normalized = trimmed.toLowerCase()
+    if (seen.has(normalized)) return
+    seen.add(normalized)
+    candidates.push(trimmed)
+  }
+
+  for (const line of lines) {
+    let match
+    while ((match = COMPANY_REGEX.exec(line)) !== null) {
+      consider(match[1])
+    }
+  }
+
+  if (candidates.length === 0) {
+    for (const line of lines) {
+      if (!line || line.length > 120) continue
+      const words = line.trim().split(/\s+/)
+      if (words.length < 2 || words.length > 8) continue
+      const uppercaseRatio = words.filter(word => /^(?:[A-Z][A-Z0-9&']+)$/.test(word)).length / words.length
+      if (uppercaseRatio >= 0.6) {
+        consider(words.join(' '))
+      }
+    }
+  }
+
+  return candidates
+}
+
+const labelConfidence = score => {
+  if (score >= 6) return 'high'
+  if (score >= 4) return 'medium'
+  if (score >= 2) return 'low'
+  return 'none'
+}
+
+module.exports = ({ text, maxChars = 20000 } = {}) => {
+  if (!text) {
+    return {
+      isPitchDeck: false,
+      confidenceScore: 0,
+      confidence: 'none',
+      summary: 'No text content was available for analysis.',
+      matchedKeywords: [],
+      fundingMentions: [],
+      investorMentions: [],
+      sectionMentions: [],
+      companyCandidates: [],
+      sampleTitle: null
+    }
+  }
+
+  const limited = text.slice(0, maxChars)
+  const normalized = normalize(limited)
+  const strongMatches = collectMatches(normalized, STRONG_KEYWORDS)
+  const fundingMatches = collectMatches(normalized, FUNDING_KEYWORDS)
+  const investorMatches = collectMatches(normalized, INVESTOR_KEYWORDS)
+  const sectionMatches = collectMatches(normalized, SECTION_KEYWORDS)
+
+  let score = 0
+  if (strongMatches.length > 0) {
+    score += 4
+  }
+  if (fundingMatches.length > 0) {
+    score += Math.min(fundingMatches.length, 2) * 1.5
+  }
+  if (investorMatches.length > 0) {
+    score += Math.min(investorMatches.length, 3) * 0.75
+  }
+  if (sectionMatches.length > 0) {
+    score += Math.min(sectionMatches.length, 6) * 0.5
+  }
+
+  const isPitchDeck = score >= 3.5 || strongMatches.length > 0
+
+  const lines = limited
+    .split(/\r?\n/)
+    .map(line => line.trim())
+    .filter(Boolean)
+
+  const interestingLine = lines.find(line => /deck|presentation|investor|fund/i.test(line)) || lines[0] || null
+  const companyCandidates = extractCompanyCandidates(lines.slice(0, 40))
+
+  const details = []
+  if (strongMatches.length > 0) {
+    details.push(`strong keywords (${strongMatches.join(', ')})`)
+  }
+  if (fundingMatches.length > 0) {
+    details.push(`funding references (${fundingMatches.join(', ')})`)
+  }
+  if (sectionMatches.length >= 3) {
+    details.push(`multiple deck sections (${sectionMatches.slice(0, 5).join(', ')})`)
+  }
+  if (investorMatches.length > 0) {
+    details.push(`investor language (${investorMatches.join(', ')})`)
+  }
+
+  const summary = details.length > 0
+    ? `Detected ${details.join('; ')}.`
+    : 'No strong pitch deck indicators detected.'
+
+  return {
+    isPitchDeck,
+    confidenceScore: score,
+    confidence: labelConfidence(score),
+    summary,
+    matchedKeywords: strongMatches,
+    fundingMentions: fundingMatches,
+    investorMentions: investorMatches,
+    sectionMentions: sectionMatches,
+    companyCandidates,
+    sampleTitle: interestingLine
+  }
+}

--- a/src/getMacOSTags.js
+++ b/src/getMacOSTags.js
@@ -1,0 +1,73 @@
+const { execFile } = require('child_process')
+const { promisify } = require('util')
+
+const execFileAsync = promisify(execFile)
+
+const sanitizeTag = (value) => {
+  if (typeof value !== 'string') return null
+  const normalized = value
+    .split('\u0000').join('')
+    .replace(/\r/g, '\n')
+  const [primary] = normalized.split(/\n+/)
+  if (!primary) return null
+  const cleaned = primary.replace(/[^\p{L}\p{N}\s-]+/gu, ' ').replace(/\s+/g, ' ').trim()
+  return cleaned || null
+}
+
+const parseMdlsOutput = (raw) => {
+  if (!raw) return []
+  const trimmed = raw.trim()
+  if (!trimmed || trimmed === '(null)') return []
+
+  const matches = []
+  const regex = /"([^"\\]*(?:\\.[^"\\]*)*)"/g
+  let match
+  while ((match = regex.exec(trimmed)) !== null) {
+    const candidate = match[1].replace(/\\"/g, '"')
+    matches.push(candidate)
+  }
+
+  if (matches.length === 0) {
+    const fallback = trimmed
+      .replace(/^\(\s*/, '')
+      .replace(/\s*\)$/, '')
+      .split(/,\s*/)
+      .map(entry => entry.replace(/^"|"$/g, ''))
+    return fallback
+  }
+
+  return matches
+}
+
+module.exports = async ({ filePath, verboseLogger }) => {
+  if (process.platform !== 'darwin') {
+    return []
+  }
+
+  try {
+    const { stdout } = await execFileAsync('mdls', ['-raw', '-name', 'kMDItemUserTags', filePath])
+    const parsed = parseMdlsOutput(stdout)
+    const sanitized = []
+    const seen = new Set()
+
+    for (const entry of parsed) {
+      const cleaned = sanitizeTag(entry)
+      if (!cleaned) continue
+      const key = cleaned.toLowerCase()
+      if (seen.has(key)) continue
+      seen.add(key)
+      sanitized.push(cleaned)
+    }
+
+    if (sanitized.length > 0 && typeof verboseLogger === 'function') {
+      verboseLogger(`🏷️ Finder tags detected: ${sanitized.join(', ')}`)
+    }
+
+    return sanitized
+  } catch (err) {
+    if (typeof verboseLogger === 'function') {
+      verboseLogger(`⚪ Unable to read Finder tags: ${err.message}`)
+    }
+    return []
+  }
+}

--- a/src/getNewName.js
+++ b/src/getNewName.js
@@ -1,45 +1,417 @@
 const changeCase = require('./changeCase')
 const getModelResponse = require('./getModelResponse')
 
+const LABEL_REGEX = /^(?:filename|file name|suggested filename|suggested file name|name|title)\s*(?:is|=|:)?\s*/i
+const QUOTE_REGEX = /[`"'“”‘’]/g
+const INVALID_FILENAME_CHARS = /[^\p{L}\p{N}\s_-]+/gu
+const DEFAULT_MAX_CONTENT_CHARS = 8000
+const DEFAULT_MAX_PROMPT_CHARS = 12000
+
+const sanitizeSegment = (segment) => {
+  if (!segment) return ''
+  const withoutQuotes = segment.replace(QUOTE_REGEX, '')
+  const withoutLabel = withoutQuotes.replace(LABEL_REGEX, '')
+  return withoutLabel
+    .replace(INVALID_FILENAME_CHARS, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+const shortenToLimit = (text, limit) => {
+  if (!text || !limit || text.length <= limit) return text
+  const words = text.split(/\s+/)
+  let candidate = ''
+
+  for (const word of words) {
+    const next = candidate ? `${candidate} ${word}` : word
+    if (next.length > limit) break
+    candidate = next
+  }
+
+  return candidate || text.slice(0, limit)
+}
+
+const extractFilenameCandidate = ({ modelResult, maxChars }) => {
+  if (!modelResult) return ''
+
+  const normalized = modelResult
+    .replace(/\r/g, '\n')
+    .split('\u0000').join('')
+    .trim()
+
+  if (!normalized) return ''
+
+  const segments = []
+  const patternRegexes = [
+    /(?:filename|file name)\s*(?:is|=|:)\s*([^\n]+)/i,
+    /(?:suggested|proposed|recommended)\s*(?:filename|file name)\s*(?:is|=|:)?\s*([^\n]+)/i,
+    /name\s*[:：]\s*([^\n]+)/i
+  ]
+
+  for (const regex of patternRegexes) {
+    const match = normalized.match(regex)
+    if (match && match[1]) segments.push(match[1])
+  }
+
+  segments.push(...normalized.split(/\r?\n/))
+  segments.push(...normalized.split(/[,;]+/))
+
+  const seen = new Set()
+
+  for (const segment of segments) {
+    const cleaned = sanitizeSegment(segment)
+    if (!cleaned) continue
+    const key = cleaned.toLowerCase()
+    if (seen.has(key)) continue
+    seen.add(key)
+
+    const shortened = shortenToLimit(cleaned, maxChars)
+    if (shortened) return shortened
+  }
+
+  const fallback = sanitizeSegment(normalized)
+  return shortenToLimit(fallback, maxChars)
+}
+
+const trimToBoundary = (text, limit) => {
+  if (!text || !limit || text.length <= limit) return text
+
+  const applySeparator = (separator) => {
+    if (!text.includes(separator)) return ''
+    const parts = text.split(separator)
+    let result = ''
+
+    for (const part of parts) {
+      if (!part) continue
+      const next = result ? `${result}${separator}${part}` : part
+      if (next.length > limit) break
+      result = next
+    }
+
+    return result
+  }
+
+  const byHyphen = applySeparator('-')
+  if (byHyphen) return byHyphen
+
+  const byUnderscore = applySeparator('_')
+  if (byUnderscore) return byUnderscore
+
+  return text.slice(0, limit).replace(/[-_]+$/g, '')
+}
+
+const enforceLengthLimit = (value, limit) => {
+  if (!value) return value
+  if (!Number.isFinite(limit) || limit <= 0) return value
+  if (value.length <= limit) return value
+  return trimToBoundary(value, limit) || value.slice(0, limit)
+}
+
+const softTruncate = (text, limit) => {
+  if (!text || !Number.isFinite(limit) || limit <= 0) return ''
+  if (text.length <= limit) return text
+
+  const slice = text.slice(0, limit)
+  const lastNewline = slice.lastIndexOf('\n')
+  if (lastNewline >= Math.floor(limit * 0.6)) {
+    return slice.slice(0, lastNewline).trim()
+  }
+
+  const lastSentenceBreak = Math.max(slice.lastIndexOf('. '), slice.lastIndexOf('! '), slice.lastIndexOf('? '))
+  if (lastSentenceBreak >= Math.floor(limit * 0.5)) {
+    return slice.slice(0, lastSentenceBreak + 1).trim()
+  }
+
+  return slice.trim()
+}
+
+const formatDateForPrompt = (value) => {
+  if (!value) return null
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toISOString().slice(0, 10)
+}
+
+const buildMetadataHint = ({ fileMetadata, metadataHints }) => {
+  if (!metadataHints || !fileMetadata) {
+    return { lines: [], fallbackDate: null }
+  }
+
+  const lines = []
+  const created = formatDateForPrompt(fileMetadata.createdAt)
+  const modified = formatDateForPrompt(fileMetadata.modifiedAt)
+
+  if (created) {
+    lines.push(`Created on ${created}`)
+  }
+
+  if (modified) {
+    lines.push(`Last modified on ${modified}`)
+  }
+
+  if (fileMetadata.sizeLabel) {
+    lines.push(`Approximate size ${fileMetadata.sizeLabel}`)
+  } else if (Number.isFinite(fileMetadata.size)) {
+    lines.push(`File size ${fileMetadata.size} bytes`)
+  }
+
+  let fallbackDate = null
+  if (created) {
+    fallbackDate = { type: 'created', value: created }
+  } else if (modified) {
+    fallbackDate = { type: 'modified', value: modified }
+  }
+
+  return { lines, fallbackDate }
+}
+
+const composePromptLines = ({
+  _case,
+  chars,
+  language,
+  videoPrompt,
+  useFilenameHint,
+  originalFileName,
+  metadataHintLines,
+  metadataFallback,
+  contentSnippet,
+  contentOriginalLength,
+  contentTruncated,
+  customPrompt
+}) => {
+  const lines = [
+    'Generate filename:',
+    '',
+    `Use ${_case}`,
+    `Max ${chars} characters`,
+    `${language} only`,
+    'No file extension',
+    'No special chars',
+    'Only key elements',
+    'One word if possible',
+    'Noun-verb format',
+    '',
+    'Respond ONLY with filename.'
+  ]
+
+  if (useFilenameHint && originalFileName) {
+    lines.push('', `Current filename for context: ${originalFileName}`)
+  }
+
+  if (metadataHintLines && metadataHintLines.length > 0) {
+    lines.push('', 'File metadata hints:')
+    lines.push(...metadataHintLines.map(line => `- ${line}`))
+    if (metadataFallback) {
+      lines.push(`If the content lacks a clear date, fall back to the ${metadataFallback.type} date above.`)
+    }
+  }
+
+  if (videoPrompt) {
+    lines.push('', 'Video summary:', videoPrompt)
+  }
+
+  if (contentSnippet) {
+    if (contentTruncated && Number.isFinite(contentOriginalLength)) {
+      lines.push('', `Content preview (first ${contentSnippet.length} of ${contentOriginalLength} characters):`, contentSnippet)
+    } else {
+      lines.push('', 'Content:', contentSnippet)
+    }
+  }
+
+  if (customPrompt) {
+    lines.push('', 'Custom instructions:', customPrompt)
+  }
+
+  return lines
+}
+
 module.exports = async options => {
-  const { _case, chars, content, language, videoPrompt, customPrompt, relativeFilePath } = options
+  const {
+    _case,
+    chars,
+    content,
+    language,
+    videoPrompt,
+    customPrompt,
+    relativeFilePath,
+    originalFileName,
+    fileMetadata,
+    metadataHints = true,
+    useFilenameHint = true
+  } = options
 
   try {
-    const promptLines = [
-      'Generate filename:',
-      '',
-      `Use ${_case}`,
-      `Max ${chars} characters`,
-      `${language} only`,
-      'No file extension',
-      'No special chars',
-      'Only key elements',
-      'One word if possible',
-      'Noun-verb format',
-      '',
-      'Respond ONLY with filename.'
-    ]
+    const originalContentLength = content ? content.length : 0
+    const maxContentChars = Number.isFinite(options.maxPromptContentChars)
+      ? Math.max(options.maxPromptContentChars, 0)
+      : DEFAULT_MAX_CONTENT_CHARS
+    const maxPromptChars = Number.isFinite(options.maxPromptChars)
+      ? Math.max(options.maxPromptChars, 2000)
+      : DEFAULT_MAX_PROMPT_CHARS
 
-    if (videoPrompt) {
-      promptLines.unshift(videoPrompt, '')
+    let contentSnippet = content || ''
+    let contentTruncated = false
+    if (contentSnippet && contentSnippet.length > maxContentChars) {
+      contentSnippet = softTruncate(contentSnippet, maxContentChars)
+      contentTruncated = true
+    }
+    if (!contentSnippet) {
+      contentSnippet = ''
     }
 
-    if (content) {
-      promptLines.push('', 'Content:', content)
+    const metadataInfo = buildMetadataHint({ fileMetadata, metadataHints })
+
+    const assemblePrompt = () => composePromptLines({
+      _case,
+      chars,
+      language,
+      videoPrompt,
+      useFilenameHint,
+      originalFileName,
+      metadataHintLines: metadataInfo.lines,
+      metadataFallback: metadataInfo.fallbackDate,
+      contentSnippet: contentSnippet || null,
+      contentOriginalLength: originalContentLength,
+      contentTruncated,
+      customPrompt
+    })
+
+    let promptLines = assemblePrompt()
+    let prompt = promptLines.join('\n')
+    let promptTrimmed = false
+
+    if (prompt.length > maxPromptChars && contentSnippet) {
+      const overflow = prompt.length - maxPromptChars
+      const targetLength = Math.max(0, contentSnippet.length - overflow - 200)
+      const shortened = targetLength > 0 ? softTruncate(contentSnippet, targetLength) : ''
+      if (shortened !== contentSnippet) {
+        contentSnippet = shortened
+        contentTruncated = true
+        promptLines = assemblePrompt()
+        prompt = promptLines.join('\n')
+      }
     }
 
-    if (customPrompt) {
-      promptLines.push('', 'Custom instructions:', customPrompt)
+    if (prompt.length > maxPromptChars) {
+      prompt = prompt.slice(0, maxPromptChars)
+      promptTrimmed = true
     }
-
-    const prompt = promptLines.join('\n')
 
     const modelResult = await getModelResponse({ ...options, prompt })
 
-    const maxChars = chars + 10
-    const text = modelResult.trim().slice(-maxChars)
-    const filename = await changeCase({ text, _case })
-    return filename
+    const safeCharLimit = Number.isFinite(chars) && chars > 0 ? Math.floor(chars) : 20
+    const candidateLimit = Math.min(safeCharLimit + 20, 120)
+    const extractedCandidate = extractFilenameCandidate({ modelResult, maxChars: candidateLimit })
+    const candidate = extractedCandidate || 'renamed file'
+
+    let filename = await changeCase({ text: candidate, _case })
+    const afterCase = filename
+    filename = enforceLengthLimit(filename, safeCharLimit)
+
+    let usedFallback = false
+    if (!extractedCandidate) {
+      usedFallback = true
+    }
+
+    let truncated = false
+    if (afterCase && filename && afterCase !== filename) {
+      truncated = true
+    }
+
+    if (!filename) {
+      const fallbackName = await changeCase({ text: 'renamed file', _case })
+      const enforcedFallback = enforceLengthLimit(fallbackName, safeCharLimit)
+      if (enforcedFallback) {
+        filename = enforcedFallback
+        usedFallback = true
+        truncated = enforcedFallback.length < fallbackName.length
+      }
+    }
+
+    if (!filename) return null
+
+    const summaryParts = []
+    if (usedFallback) {
+      summaryParts.push('Used fallback phrase because the model response did not include a clean filename.')
+    } else {
+      summaryParts.push(`Used model candidate "${candidate}".`)
+    }
+    summaryParts.push(`Applied ${_case} case and a ${safeCharLimit}-character limit.`)
+    if (truncated) {
+      summaryParts.push('The result was shortened to satisfy the length constraint.')
+    }
+    if (videoPrompt) {
+      summaryParts.push('Video frame summary influenced the prompt.')
+    }
+    if (content) {
+      const contentDetail = contentTruncated
+        ? `Text was extracted from the source file and truncated to ${contentSnippet.length} characters to stay within the context limit.`
+        : 'Text was extracted from the source file before generating the name.'
+      summaryParts.push(contentDetail)
+    }
+    if (customPrompt) {
+      summaryParts.push('Custom instructions were included in the prompt.')
+    }
+    if (useFilenameHint && originalFileName) {
+      summaryParts.push(`Provided the original filename "${originalFileName}" as a hint.`)
+    }
+    if (metadataHints) {
+      if (fileMetadata) {
+        const parts = []
+        if (metadataInfo.lines.length > 0) {
+          parts.push('Shared file metadata with the model')
+        }
+        if (metadataInfo.fallbackDate) {
+          parts.push(`Highlighted the ${metadataInfo.fallbackDate.type} date as a fallback reference.`)
+        }
+        if (parts.length > 0) {
+          summaryParts.push(parts.join(' '))
+        }
+      } else {
+        summaryParts.push('Metadata hints were enabled but no filesystem metadata was available.')
+      }
+    }
+    if (promptTrimmed) {
+      summaryParts.push('The composed prompt was trimmed to keep the total length within the context window.')
+    }
+
+    const summary = summaryParts.join(' ')
+
+    const source = content
+      ? 'text'
+      : Array.isArray(options.images) && options.images.length > 0
+        ? 'visual'
+        : 'prompt-only'
+
+    const context = {
+      summary,
+      candidate,
+      usedFallback,
+      caseStyle: _case,
+      charLimit: safeCharLimit,
+      truncated,
+      finalName: filename,
+      source,
+      modelResponse: modelResult,
+      modelResponsePreview: modelResult ? modelResult.slice(0, 280) : null,
+      customPromptIncluded: Boolean(customPrompt),
+      videoSummaryIncluded: Boolean(videoPrompt),
+      contentLength: content ? content.length : 0,
+      contentSnippetLength: contentSnippet ? contentSnippet.length : 0,
+      contentTruncated,
+      promptLength: prompt.length,
+      promptPreview: prompt.slice(0, 500),
+      promptTrimmed,
+      maxPromptChars,
+      maxContentChars,
+      filenameHintIncluded: Boolean(useFilenameHint && originalFileName),
+      metadataHintIncluded: Boolean(metadataHints && fileMetadata),
+      metadataFallback: metadataInfo.fallbackDate,
+      originalFileName,
+      metadataSummary: metadataInfo.lines
+    }
+
+    return { filename, context }
   } catch (err) {
     console.log(`🔴 Model error: ${err.message} (${relativeFilePath})`)
   }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,8 @@ const configureYargs = require('./configureYargs')
 const main = async () => {
   try {
     const { argv, config } = await configureYargs()
-    const [inputPath] = argv._
+    const [rawInputPath] = argv._
+    const inputPath = typeof rawInputPath === 'string' ? rawInputPath.trim() : rawInputPath
 
     if (!inputPath) {
       console.log('🔴 Please provide a file or folder path')

--- a/src/processDirectory.js
+++ b/src/processDirectory.js
@@ -3,8 +3,15 @@ const fs = require('fs').promises
 
 const processFile = require('./processFile')
 
+const logVerbose = (verbose, message) => {
+  if (!verbose) return
+  console.log(message)
+}
+
 const processDirectory = async ({ options, inputPath }) => {
   try {
+    const { verbose } = options
+    logVerbose(verbose, `📁 Entering directory: ${inputPath}`)
     const files = await fs.readdir(inputPath)
     for (const file of files) {
       const filePath = path.join(inputPath, file)
@@ -12,6 +19,7 @@ const processDirectory = async ({ options, inputPath }) => {
       if (fileStats.isFile()) {
         await processFile({ ...options, filePath })
       } else if (fileStats.isDirectory() && options.includeSubdirectories) {
+        logVerbose(verbose, `📂 Descending into subdirectory: ${filePath}`)
         await processDirectory({ options, inputPath: filePath })
       }
     }

--- a/src/processFile.js
+++ b/src/processFile.js
@@ -1,5 +1,7 @@
+const fs = require('fs').promises
 const path = require('path')
 const { v4: uuidv4 } = require('uuid')
+const readline = require('readline')
 
 const isImage = require('./isImage')
 const isVideo = require('./isVideo')
@@ -10,13 +12,96 @@ const readFileContent = require('./readFileContent')
 const deleteDirectory = require('./deleteDirectory')
 const isProcessableFile = require('./isProcessableFile')
 
+const logVerbose = (verbose, message) => {
+  if (!verbose) return
+  console.log(message)
+}
+
+const promptForConfirmation = async ({ question, forceChange, nonInteractiveMessage }) => {
+  if (forceChange) return true
+
+  if (!process.stdin.isTTY) {
+    if (nonInteractiveMessage) {
+      console.log(nonInteractiveMessage)
+    }
+    return false
+  }
+
+  return await new Promise(resolve => {
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout
+    })
+
+    rl.question(question, answer => {
+      rl.close()
+      const normalized = answer.trim().toLowerCase()
+      resolve(normalized === 'y' || normalized === 'yes')
+    })
+  })
+}
+
 module.exports = async options => {
+  const { filePath } = options
+  let framesOutputDir
+  let ext
+  let verboseFlag = false
+  let relativeFilePath = ''
+
   try {
-    const { frames, filePath, inputPath } = options
+    const {
+      frames,
+      inputPath,
+      convertBinary,
+      verbose,
+      forceChange,
+      recordLogEntry,
+      metadataHints,
+      useFilenameHint
+    } = options
+
+    verboseFlag = verbose
 
     const fileName = path.basename(filePath)
-    const ext = path.extname(filePath).toLowerCase()
-    const relativeFilePath = path.relative(inputPath, filePath)
+    ext = path.extname(filePath).toLowerCase()
+    relativeFilePath = path.relative(inputPath, filePath) || fileName
+
+    let fileMetadata = null
+    try {
+      const stats = await fs.stat(filePath)
+      const createdAt = stats.birthtime instanceof Date && !Number.isNaN(stats.birthtime.getTime())
+        ? stats.birthtime.toISOString()
+        : null
+      const modifiedAt = stats.mtime instanceof Date && !Number.isNaN(stats.mtime.getTime())
+        ? stats.mtime.toISOString()
+        : null
+
+      const prettySize = (() => {
+        if (!Number.isFinite(stats.size)) return null
+        if (stats.size < 1024) return `${stats.size} B`
+        const units = ['KB', 'MB', 'GB', 'TB']
+        let value = stats.size / 1024
+        let unitIndex = 0
+        while (value >= 1024 && unitIndex < units.length - 1) {
+          value /= 1024
+          unitIndex += 1
+        }
+        return `${value.toFixed(value >= 10 ? 0 : 1)} ${units[unitIndex]}`
+      })()
+
+      fileMetadata = {
+        size: Number.isFinite(stats.size) ? stats.size : null,
+        sizeLabel: prettySize,
+        createdAt,
+        modifiedAt
+      }
+
+      logVerbose(verbose, `🗂️ Metadata — size: ${prettySize || stats.size || 'unknown'}, created: ${createdAt || 'n/a'}, modified: ${modifiedAt || 'n/a'}`)
+    } catch (metadataError) {
+      logVerbose(verbose, `⚪ Unable to read metadata for ${relativeFilePath}: ${metadataError.message}`)
+    }
+
+    logVerbose(verbose, `🔍 Processing file: ${relativeFilePath}`)
 
     if (fileName === '.DS_Store') return
 
@@ -28,10 +113,11 @@ module.exports = async options => {
     let content
     let videoPrompt
     let images = []
-    let framesOutputDir
     if (isImage({ ext })) {
+      logVerbose(verbose, `🖼️ Detected image: ${relativeFilePath}`)
       images.push(filePath)
     } else if (isVideo({ ext })) {
+      logVerbose(verbose, `🎞️ Detected video: ${relativeFilePath} — extracting frames`)
       framesOutputDir = `/tmp/ai-renamer/${uuidv4()}`
       const _extractedFrames = await extractFrames({
         frames,
@@ -40,25 +126,79 @@ module.exports = async options => {
       })
       images = _extractedFrames.images
       videoPrompt = _extractedFrames.videoPrompt
+      logVerbose(verbose, `🎯 Extracted ${images.length} frame(s) from ${relativeFilePath}`)
     } else {
-      content = await readFileContent({ filePath })
+      logVerbose(verbose, `📄 Extracting text content from: ${relativeFilePath}`)
+      content = await readFileContent({ filePath, convertBinary, verbose })
       if (!content) {
         console.log(`🔴 No text content: ${relativeFilePath}`)
         return
       }
+      logVerbose(verbose, `✅ Extracted ${content.length} characters from ${relativeFilePath}`)
     }
 
-    const newName = await getNewName({ ...options, images, content, videoPrompt, relativeFilePath })
-    if (!newName) return
+    const newNameResult = await getNewName({
+      ...options,
+      images,
+      content,
+      videoPrompt,
+      relativeFilePath,
+      originalFileName: fileName,
+      fileMetadata,
+      metadataHints,
+      useFilenameHint
+    })
+    if (!newNameResult || !newNameResult.filename) return
 
-    const newFileName = await saveFile({ ext, newName, filePath })
+    const { filename: proposedName, context: nameContext } = newNameResult
+
+    if (nameContext && nameContext.summary) {
+      console.log(`ℹ️ ${nameContext.summary}`)
+    }
+
+    const proposedRelativeNewPath = path.join(path.dirname(relativeFilePath), `${proposedName}${ext}`)
+    const confirmed = await promptForConfirmation({
+      question: `Rename "${relativeFilePath}" to "${proposedRelativeNewPath}"? (y/N): `,
+      forceChange,
+      nonInteractiveMessage: `🟡 Skipping rename for ${relativeFilePath} because confirmations are required but no interactive terminal is available. Use --force-change to bypass prompts.`
+    })
+
+    if (!confirmed) {
+      console.log(`⚪ Skipped rename: ${relativeFilePath}`)
+      return
+    }
+
+    const newFileName = await saveFile({ ext, newName: proposedName, filePath })
     const relativeNewFilePath = path.join(path.dirname(relativeFilePath), newFileName)
     console.log(`🟢 Renamed: ${relativeFilePath} to ${relativeNewFilePath}`)
 
-    if (isVideo({ ext }) && framesOutputDir) {
-      await deleteDirectory({ folderPath: framesOutputDir })
+    if (typeof recordLogEntry === 'function') {
+      const newAbsolutePath = path.resolve(path.dirname(filePath), newFileName)
+      const confirmationSource = forceChange ? 'force-change flag' : 'user confirmed'
+      const logEntry = {
+        originalPath: path.resolve(filePath),
+        newPath: newAbsolutePath,
+        originalName: path.basename(filePath),
+        newName: newFileName,
+        originalRelativePath: relativeFilePath,
+        newRelativePath: relativeNewFilePath,
+        acceptedAt: new Date().toISOString(),
+        confirmation: confirmationSource,
+        context: nameContext,
+        fileMetadata
+      }
+      recordLogEntry(logEntry)
     }
   } catch (err) {
     console.log(err.message)
+  } finally {
+    if (ext && isVideo({ ext }) && framesOutputDir) {
+      logVerbose(verboseFlag, `🧹 Cleaning up extracted frames for ${relativeFilePath || filePath}`)
+      try {
+        await deleteDirectory({ folderPath: framesOutputDir })
+      } catch (cleanupError) {
+        console.log(`🔴 Failed to clean up frames for ${relativeFilePath || filePath}: ${cleanupError.message}`)
+      }
+    }
   }
 }

--- a/src/processPath.js
+++ b/src/processPath.js
@@ -23,7 +23,11 @@ module.exports = async ({
   defaultLogPath,
   defaultLog,
   defaultUseFilenameHint,
-  defaultMetadataHints
+  defaultMetadataHints,
+  defaultAppendTags,
+  defaultCompanyFocus,
+  defaultPeopleFocus,
+  defaultProjectFocus
 }) => {
   try {
     const provider = defaultProvider || 'ollama'
@@ -97,6 +101,38 @@ module.exports = async ({
     const metadataHints = interpretBoolean(defaultMetadataHints, true)
     console.log(`⚪ Use metadata hints: ${metadataHints}`)
 
+    const appendTags = interpretBoolean(defaultAppendTags, false)
+    console.log(`⚪ Append Finder tags: ${appendTags}`)
+
+    const companyFocus = interpretBoolean(defaultCompanyFocus, false)
+    const peopleFocus = interpretBoolean(defaultPeopleFocus, false)
+    const projectFocus = interpretBoolean(defaultProjectFocus, false)
+
+    const focusFlags = []
+    if (companyFocus) focusFlags.push('company')
+    if (peopleFocus) focusFlags.push('people')
+    if (projectFocus) focusFlags.push('project')
+
+    const focusPriority = ['project', 'company', 'people']
+    let promptFocus = 'balanced'
+    if (focusFlags.length === 1) {
+      promptFocus = focusFlags[0]
+    } else if (focusFlags.length > 1) {
+      for (const candidate of focusPriority) {
+        if (focusFlags.includes(candidate)) {
+          promptFocus = candidate
+          break
+        }
+      }
+      console.log(`⚪ Multiple prompt focus flags detected (${focusFlags.join(', ')}). Using ${promptFocus} focus.`)
+    }
+
+    if (focusFlags.length === 0) {
+      console.log('⚪ Prompt focus: balanced')
+    } else {
+      console.log(`⚪ Prompt focus: ${promptFocus}`)
+    }
+
     const deriveCommandLabel = () => {
       const argvSegments = process.argv.slice(1)
       for (let i = argvSegments.length - 1; i >= 0; i--) {
@@ -154,7 +190,12 @@ module.exports = async ({
       logEnabled,
       resolvedLogPath,
       useFilenameHint,
-      metadataHints
+      metadataHints,
+      appendTags,
+      promptFocus,
+      companyFocus,
+      peopleFocus,
+      projectFocus
     }
 
     const logEntries = []
@@ -191,7 +232,12 @@ module.exports = async ({
             verbose,
             forceChange,
             useFilenameHint,
-            metadataHints
+            metadataHints,
+            appendTags,
+            promptFocus,
+            companyFocus,
+            peopleFocus,
+            projectFocus
           },
           renames: logEntries
         }

--- a/src/processPath.js
+++ b/src/processPath.js
@@ -1,4 +1,5 @@
 const fs = require('fs').promises
+const path = require('path')
 
 const processFile = require('./processFile')
 const chooseModel = require('./chooseModel')
@@ -15,7 +16,14 @@ module.exports = async ({
   defaultLanguage,
   defaultProvider,
   defaultCustomPrompt,
-  defaultIncludeSubdirectories
+  defaultIncludeSubdirectories,
+  defaultConvertBinary,
+  defaultVerbose,
+  defaultForceChange,
+  defaultLogPath,
+  defaultLog,
+  defaultUseFilenameHint,
+  defaultMetadataHints
 }) => {
   try {
     const provider = defaultProvider || 'ollama'
@@ -51,12 +59,78 @@ module.exports = async ({
     const language = defaultLanguage || 'English'
     console.log(`⚪ Language: ${language}`)
 
-    const includeSubdirectories = defaultIncludeSubdirectories === 'true' || false
+    const interpretBoolean = (value, fallback = false) => {
+      if (value === undefined) return fallback
+      if (typeof value === 'boolean') return value
+      if (typeof value === 'string') {
+        const lowered = value.toLowerCase()
+        if (lowered === 'true') return true
+        if (lowered === 'false') return false
+      }
+
+      return fallback
+    }
+
+    const includeSubdirectories = interpretBoolean(defaultIncludeSubdirectories, false)
     console.log(`⚪ Include subdirectories: ${includeSubdirectories}`)
 
     const customPrompt = defaultCustomPrompt || null
     if (customPrompt) {
       console.log(`⚪ Custom Prompt: ${customPrompt}`)
+    }
+
+    const convertBinary = interpretBoolean(defaultConvertBinary, false)
+    console.log(`⚪ Convert legacy Office binaries: ${convertBinary}`)
+
+    const verbose = interpretBoolean(defaultVerbose, false)
+    console.log(`⚪ Verbose logging: ${verbose}`)
+
+    const forceChange = interpretBoolean(defaultForceChange, false)
+    console.log(`⚪ Skip confirmation prompts: ${forceChange}`)
+
+    const logEnabled = defaultLog !== undefined ? interpretBoolean(defaultLog, true) : true
+    console.log(`⚪ Write run log: ${logEnabled}`)
+
+    const useFilenameHint = interpretBoolean(defaultUseFilenameHint, true)
+    console.log(`⚪ Use filename hint: ${useFilenameHint}`)
+
+    const metadataHints = interpretBoolean(defaultMetadataHints, true)
+    console.log(`⚪ Use metadata hints: ${metadataHints}`)
+
+    const deriveCommandLabel = () => {
+      const argvSegments = process.argv.slice(1)
+      for (let i = argvSegments.length - 1; i >= 0; i--) {
+        const base = path.basename(argvSegments[i])
+        if (base.toLowerCase().includes('ai-renamer')) {
+          return 'ai-renamer'
+        }
+      }
+
+      const scriptName = process.argv[1] ? path.basename(process.argv[1]) : null
+      if (scriptName === 'index.js') return 'ai-renamer'
+      if (scriptName) return scriptName.replace(/\.js$/i, '')
+
+      const binary = process.argv[0] ? path.basename(process.argv[0]) : 'ai-renamer'
+      return binary || 'ai-renamer'
+    }
+
+    const sanitizeForFilename = (value) => {
+      return value
+        .replace(/[^a-z0-9-_]+/gi, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '') || 'ai-renamer'
+    }
+
+    const commandLabel = sanitizeForFilename(deriveCommandLabel())
+    const timestamp = new Date().toISOString().replace(/[:]/g, '-')
+    const defaultLogFileName = `${commandLabel}-${timestamp}.log`
+
+    const resolvedLogPath = logEnabled
+      ? path.resolve(defaultLogPath || defaultLogFileName)
+      : null
+
+    if (logEnabled) {
+      console.log(`⚪ Log file: ${resolvedLogPath}`)
     }
 
     console.log('--------------------------------------------------')
@@ -73,13 +147,60 @@ module.exports = async ({
       provider,
       inputPath,
       includeSubdirectories,
-      customPrompt
+      customPrompt,
+      convertBinary,
+      verbose,
+      forceChange,
+      logEnabled,
+      resolvedLogPath,
+      useFilenameHint,
+      metadataHints
+    }
+
+    const logEntries = []
+
+    const recordLogEntry = entry => {
+      if (!logEnabled) return
+      logEntries.push(entry)
     }
 
     if (stats.isDirectory()) {
-      await processDirectory({ options, inputPath })
+      await processDirectory({ options: { ...options, recordLogEntry }, inputPath })
     } else if (stats.isFile()) {
-      await processFile({ ...options, filePath: inputPath })
+      await processFile({ ...options, recordLogEntry, filePath: inputPath })
+    }
+
+    if (logEnabled) {
+      try {
+        await fs.mkdir(path.dirname(resolvedLogPath), { recursive: true })
+        const logPayload = {
+          generatedAt: new Date().toISOString(),
+          command: process.argv,
+          inputPath,
+          settings: {
+            provider,
+            baseURL,
+            model,
+            frames,
+            case: _case,
+            chars,
+            language,
+            includeSubdirectories,
+            customPrompt,
+            convertBinary,
+            verbose,
+            forceChange,
+            useFilenameHint,
+            metadataHints
+          },
+          renames: logEntries
+        }
+
+        await fs.writeFile(resolvedLogPath, JSON.stringify(logPayload, null, 2))
+        console.log(`📝 Run log saved to ${resolvedLogPath}`)
+      } catch (err) {
+        console.log(`🔴 Failed to write log: ${err.message}`)
+      }
     }
   } catch (err) {
     console.log(err.message)

--- a/src/processPath.js
+++ b/src/processPath.js
@@ -25,6 +25,7 @@ module.exports = async ({
   defaultUseFilenameHint,
   defaultMetadataHints,
   defaultAppendTags,
+  defaultPitchDeckOnly,
   defaultCompanyFocus,
   defaultPeopleFocus,
   defaultProjectFocus
@@ -103,6 +104,9 @@ module.exports = async ({
 
     const appendTags = interpretBoolean(defaultAppendTags, false)
     console.log(`⚪ Append Finder tags: ${appendTags}`)
+
+    const pitchDeckOnly = interpretBoolean(defaultPitchDeckOnly, false)
+    console.log(`⚪ Startup pitch deck mode: ${pitchDeckOnly}`)
 
     const companyFocus = interpretBoolean(defaultCompanyFocus, false)
     const peopleFocus = interpretBoolean(defaultPeopleFocus, false)
@@ -192,6 +196,7 @@ module.exports = async ({
       useFilenameHint,
       metadataHints,
       appendTags,
+      pitchDeckOnly,
       promptFocus,
       companyFocus,
       peopleFocus,
@@ -241,6 +246,7 @@ module.exports = async ({
             useFilenameHint,
             metadataHints,
             appendTags,
+            pitchDeckOnly,
             promptFocus,
             companyFocus,
             peopleFocus,

--- a/src/readFileContent.js
+++ b/src/readFileContent.js
@@ -1,22 +1,505 @@
 const path = require('path')
+const { promises: fs } = require('fs')
+const { inflateRawSync } = require('zlib')
 const pdf = require('pdf-parse')
-const fs = require('fs').promises
 
-module.exports = async ({ filePath }) => {
-  try {
-    const ext = path.extname(filePath).toLowerCase()
+const { convertBinaryOfficeToDocx } = require('./binaryOfficeConversion')
 
-    let content = ''
-    if (ext === '.pdf') {
-      const dataBuffer = await fs.readFile(filePath)
-      const pdfData = await pdf(dataBuffer)
-      content = pdfData.text.trim()
-    } else {
-      content = fs.readFile(filePath, 'utf8')
+const logVerbose = (verbose, message) => {
+  if (!verbose) return
+  console.log(message)
+}
+
+const DOCX_LIKE_EXTENSIONS = new Set(['.docx', '.docm', '.dotx', '.dotm'])
+const PPTX_LIKE_EXTENSIONS = new Set(['.pptx', '.pptm', '.ppsx', '.ppsm', '.potx', '.potm'])
+const XLSX_LIKE_EXTENSIONS = new Set(['.xlsx', '.xlsm', '.xlsb', '.xltx', '.xltm'])
+const BINARY_OFFICE_WARNINGS = {
+  '.doc': 'The .doc format is not supported for text extraction. Please convert the file to .docx or run with --convertbinary.',
+  '.dot': 'The .dot template format is not supported for text extraction. Please convert the file to .dotx or run with --convertbinary.',
+  '.ppt': 'The .ppt format is not supported for text extraction. Please convert the file to .pptx or run with --convertbinary.',
+  '.pps': 'The .pps format is not supported for text extraction. Please convert the file to .ppsx or run with --convertbinary.',
+  '.pot': 'The .pot template format is not supported for text extraction. Please convert the file to .potx or run with --convertbinary.',
+  '.xls': 'The .xls format is not supported for text extraction. Please convert the file to .xlsx or run with --convertbinary.',
+  '.xlt': 'The .xlt template format is not supported for text extraction. Please convert the file to .xltx or run with --convertbinary.'
+}
+
+const OPEN_DOCUMENT_TEXT_EXTENSIONS = new Set(['.odt'])
+const OPEN_DOCUMENT_PRESENTATION_EXTENSIONS = new Set(['.odp'])
+const OPEN_DOCUMENT_SPREADSHEET_EXTENSIONS = new Set(['.ods'])
+const KEYNOTE_EXTENSIONS = new Set(['.key'])
+
+const EOCD_SIGNATURE = 0x06054b50
+const CENTRAL_DIRECTORY_SIGNATURE = 0x02014b50
+const LOCAL_FILE_HEADER_SIGNATURE = 0x04034b50
+
+const decodeXmlEntities = (input) => {
+  if (!input) return ''
+  return input
+    .replace(/&#x([0-9a-fA-F]+);/g, (_, hex) => {
+      const codePoint = parseInt(hex, 16)
+      return Number.isNaN(codePoint) ? '' : String.fromCodePoint(codePoint)
+    })
+    .replace(/&#([0-9]+);/g, (_, dec) => {
+      const codePoint = parseInt(dec, 10)
+      return Number.isNaN(codePoint) ? '' : String.fromCodePoint(codePoint)
+    })
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+const normalizeWhitespace = (text) => {
+  return text
+    .split('\n')
+    .map((line) => line.replace(/[\t ]+/g, ' ').trim())
+    .filter(Boolean)
+    .join('\n')
+}
+
+const parseZipEntries = (buffer) => {
+  if (!Buffer.isBuffer(buffer)) {
+    throw new Error('Expected a buffer when parsing a zip archive')
+  }
+
+  let eocdOffset = -1
+  for (let i = buffer.length - 22; i >= 0; i--) {
+    if (buffer.readUInt32LE(i) === EOCD_SIGNATURE) {
+      eocdOffset = i
+      break
+    }
+  }
+
+  if (eocdOffset === -1) {
+    throw new Error('Invalid archive: End of central directory record not found')
+  }
+
+  const centralDirectoryOffset = buffer.readUInt32LE(eocdOffset + 16)
+  const totalEntries = buffer.readUInt16LE(eocdOffset + 10)
+
+  const entries = new Map()
+  let offset = centralDirectoryOffset
+
+  for (let i = 0; i < totalEntries; i++) {
+    const signature = buffer.readUInt32LE(offset)
+    if (signature !== CENTRAL_DIRECTORY_SIGNATURE) {
+      break
     }
 
-    return content
-  } catch (err) {
-    throw new Error(err.message)
+    const compressionMethod = buffer.readUInt16LE(offset + 10)
+    const compressedSize = buffer.readUInt32LE(offset + 20)
+    const fileNameLength = buffer.readUInt16LE(offset + 28)
+    const extraFieldLength = buffer.readUInt16LE(offset + 30)
+    const commentLength = buffer.readUInt16LE(offset + 32)
+    const localHeaderOffset = buffer.readUInt32LE(offset + 42)
+
+    const nameStart = offset + 46
+    const fileName = buffer.slice(nameStart, nameStart + fileNameLength).toString('utf8')
+
+    const localHeaderSignature = buffer.readUInt32LE(localHeaderOffset)
+    if (localHeaderSignature !== LOCAL_FILE_HEADER_SIGNATURE) {
+      offset = nameStart + fileNameLength + extraFieldLength + commentLength
+      continue
+    }
+
+    const localFileNameLength = buffer.readUInt16LE(localHeaderOffset + 26)
+    const localExtraFieldLength = buffer.readUInt16LE(localHeaderOffset + 28)
+    const dataStart = localHeaderOffset + 30 + localFileNameLength + localExtraFieldLength
+    const dataEnd = dataStart + compressedSize
+    const fileData = buffer.slice(dataStart, dataEnd)
+
+    let decompressed
+    if (compressionMethod === 0) {
+      decompressed = fileData
+    } else if (compressionMethod === 8) {
+      decompressed = inflateRawSync(fileData)
+    } else {
+      throw new Error(`Unsupported compression method ${compressionMethod} encountered in archive`)
+    }
+
+    entries.set(fileName, decompressed)
+
+    offset = nameStart + fileNameLength + extraFieldLength + commentLength
   }
+
+  return entries
+}
+
+const extractDocxText = (entries) => {
+  const relevantFiles = Array.from(entries.keys()).filter((file) => {
+    if (!file.startsWith('word/') || !file.endsWith('.xml')) return false
+    return /document|header|footer|footnotes|endnotes/i.test(file)
+  }).sort()
+
+  const paragraphs = []
+  const paragraphRegex = /<w:p[\s\S]*?<\/w:p>/g
+
+  const extractParagraphText = (paragraphXml) => {
+    const tokensRegex = /(<w:t[^>]*>[\s\S]*?<\/w:t>)|(<w:tab[^>]*\/>)+|(<w:br[^>]*\/>)|(<w:cr[^>]*\/>)|(<w:pBreak[^>]*\/>)|(<w:tbl>[\s\S]*?<\/w:tbl>)/g
+    tokensRegex.lastIndex = 0
+    const tokens = []
+    let match
+
+    while ((match = tokensRegex.exec(paragraphXml)) !== null) {
+      const [token] = match
+      if (token.startsWith('<w:t')) {
+        const text = token.replace(/<w:t[^>]*>/, '').replace(/<\/w:t>/, '')
+        tokens.push(decodeXmlEntities(text))
+      } else if (token.startsWith('<w:tab')) {
+        const tabCount = (token.match(/<w:tab[^>]*\/>/g) || ['']).length
+        tokens.push('\t'.repeat(tabCount))
+      } else if (token.startsWith('<w:tbl')) {
+        const cellText = token
+          .replace(/<w:tr[^>]*>/g, '\n')
+          .replace(/<\/w:tr>/g, '\n')
+          .replace(/<w:tc[^>]*>/g, '\t')
+          .replace(/<\/w:tc>/g, '\t')
+        const stripped = cellText.replace(/<[^>]+>/g, '')
+        tokens.push(decodeXmlEntities(stripped))
+      } else {
+        tokens.push('\n')
+      }
+    }
+
+    const combined = tokens.join('')
+    const lines = combined.split('\n')
+      .map((line) => line.replace(/[\t ]+/g, ' ').trim())
+      .filter(Boolean)
+    return lines.join('\n')
+  }
+
+  for (const file of relevantFiles) {
+    const xml = entries.get(file).toString('utf8')
+    paragraphRegex.lastIndex = 0
+    let match
+    while ((match = paragraphRegex.exec(xml)) !== null) {
+      const paragraphText = extractParagraphText(match[0])
+      if (paragraphText) {
+        paragraphs.push(paragraphText)
+      }
+    }
+  }
+
+  return paragraphs.join('\n\n').trim()
+}
+
+const naturalCompare = (a, b) => {
+  return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+const extractPptxText = (entries) => {
+  const slideFiles = Array.from(entries.keys())
+    .filter((file) => /^ppt\/slides\/slide[0-9]+\.xml$/i.test(file))
+    .sort(naturalCompare)
+
+  const slides = []
+  for (const file of slideFiles) {
+    const xml = entries.get(file).toString('utf8')
+      .replace(/<a:br[^>]*\/>/g, '\n')
+      .replace(/<a:tab[^>]*\/>/g, '\t')
+
+    const textSegments = []
+    const textRegex = /<a:t[^>]*>([\s\S]*?)<\/a:t>/g
+    let match
+    while ((match = textRegex.exec(xml)) !== null) {
+      const segment = decodeXmlEntities(match[1])
+      const cleaned = segment.split('\n').map((line) => line.replace(/[\t ]+/g, ' ').trim()).filter(Boolean).join('\n')
+      if (cleaned) {
+        textSegments.push(cleaned)
+      }
+    }
+
+    const slideText = textSegments.join('\n')
+    if (slideText) {
+      slides.push(slideText)
+    }
+  }
+
+  return slides.join('\n\n').trim()
+}
+
+const extractKeynoteText = (entries) => {
+  let keynoteFile = null
+  for (const candidate of ['index.apxl', 'Index.apxl']) {
+    if (entries.has(candidate)) {
+      keynoteFile = entries.get(candidate)
+      break
+    }
+  }
+
+  if (!keynoteFile) return ''
+
+  const xml = keynoteFile.toString('utf8')
+    .replace(/<sf:tab[^>]*\/>/g, '\t')
+    .replace(/<sf:lineBreak[^>]*\/>/g, '\n')
+
+  const text = xml.replace(/<[^>]+>/g, ' ')
+  return normalizeWhitespace(decodeXmlEntities(text))
+}
+
+const extractSharedStrings = (entries) => {
+  const sharedStrings = []
+  if (!entries.has('xl/sharedStrings.xml')) return sharedStrings
+
+  const xml = entries.get('xl/sharedStrings.xml').toString('utf8')
+  const stringRegex = /<si[^>]*>([\s\S]*?)<\/si>/g
+  let match
+  while ((match = stringRegex.exec(xml)) !== null) {
+    const segment = match[1]
+    const textPieces = []
+    const textRegex = /<t[^>]*>([\s\S]*?)<\/t>/g
+    let textMatch
+    while ((textMatch = textRegex.exec(segment)) !== null) {
+      textPieces.push(decodeXmlEntities(textMatch[1]))
+    }
+    const combined = textPieces.join('')
+    sharedStrings.push(combined)
+  }
+
+  return sharedStrings
+}
+
+const buildSheetNameMap = (entries) => {
+  const sheetNameByRelId = new Map()
+  const sheetTargets = new Map()
+
+  if (entries.has('xl/workbook.xml')) {
+    const workbookXml = entries.get('xl/workbook.xml').toString('utf8')
+    const sheetRegex = /<sheet[^>]*name="([^"]+)"[^>]*r:id="([^"]+)"[^>]*>/g
+    let match
+    while ((match = sheetRegex.exec(workbookXml)) !== null) {
+      const [, name, relId] = match
+      sheetNameByRelId.set(relId, decodeXmlEntities(name))
+    }
+  }
+
+  if (entries.has('xl/_rels/workbook.xml.rels')) {
+    const relsXml = entries.get('xl/_rels/workbook.xml.rels').toString('utf8')
+    const relRegex = /<Relationship[^>]*Id="([^"]+)"[^>]*Target="([^"]+)"/g
+    let match
+    while ((match = relRegex.exec(relsXml)) !== null) {
+      const [, relId, target] = match
+      const sheetName = sheetNameByRelId.get(relId)
+      if (!sheetName) continue
+
+      let normalizedTarget = target
+      if (!normalizedTarget.startsWith('/')) {
+        normalizedTarget = `xl/${normalizedTarget.replace(/^\.\//, '')}`
+      } else {
+        normalizedTarget = `xl${normalizedTarget}`
+      }
+      sheetTargets.set(normalizedTarget, sheetName)
+    }
+  }
+
+  return sheetTargets
+}
+
+const extractSheetText = (xml, sharedStrings) => {
+  const rows = []
+  const rowRegex = /<row[^>]*>([\s\S]*?)<\/row>/g
+  let rowMatch
+
+  while ((rowMatch = rowRegex.exec(xml)) !== null) {
+    const rowCells = []
+    const cellRegex = /<c([^>]*)>([\s\S]*?)<\/c>/g
+    let cellMatch
+    while ((cellMatch = cellRegex.exec(rowMatch[1])) !== null) {
+      const [, rawAttributes, cellBody] = cellMatch
+      const typeMatch = /t="([^"]+)"/.exec(rawAttributes)
+      let cellValue = ''
+
+      if (typeMatch && typeMatch[1] === 's') {
+        const valueMatch = /<v>([\s\S]*?)<\/v>/.exec(cellBody)
+        if (valueMatch) {
+          const index = parseInt(valueMatch[1], 10)
+          if (!Number.isNaN(index) && sharedStrings[index]) {
+            cellValue = sharedStrings[index]
+          }
+        }
+      } else if (typeMatch && typeMatch[1] === 'inlineStr') {
+        const inlinePieces = []
+        const inlineRegex = /<t[^>]*>([\s\S]*?)<\/t>/g
+        let inlineMatch
+        while ((inlineMatch = inlineRegex.exec(cellBody)) !== null) {
+          inlinePieces.push(decodeXmlEntities(inlineMatch[1]))
+        }
+        cellValue = inlinePieces.join('')
+      } else {
+        const valueMatch = /<v>([\s\S]*?)<\/v>/.exec(cellBody)
+        if (valueMatch) {
+          cellValue = decodeXmlEntities(valueMatch[1])
+        }
+      }
+
+      if (!cellValue) {
+        const textMatch = /<t[^>]*>([\s\S]*?)<\/t>/.exec(cellBody)
+        if (textMatch) {
+          cellValue = decodeXmlEntities(textMatch[1])
+        }
+      }
+
+      rowCells.push(cellValue.replace(/[\t ]+/g, ' ').trim())
+    }
+
+    if (rowCells.some((cell) => cell.length > 0)) {
+      rows.push(rowCells)
+    }
+  }
+
+  const lines = rows.map((cells) => cells.join('\t').trim()).filter(Boolean)
+  return lines.join('\n')
+}
+
+const extractXlsxText = (entries) => {
+  const sharedStrings = extractSharedStrings(entries)
+  const sheetNames = buildSheetNameMap(entries)
+
+  const sheetFiles = Array.from(entries.keys())
+    .filter((file) => /^xl\/worksheets\/[\w-]+\.xml$/i.test(file))
+    .sort(naturalCompare)
+
+  const sheets = []
+  for (const file of sheetFiles) {
+    const sheetXml = entries.get(file).toString('utf8')
+    const sheetText = extractSheetText(sheetXml, sharedStrings)
+    if (sheetText) {
+      const displayName = sheetNames.get(file) || file.replace(/^xl\/worksheets\//, '').replace(/\.xml$/i, '')
+      sheets.push(`Sheet: ${displayName}\n${sheetText}`)
+    }
+  }
+
+  return sheets.join('\n\n').trim()
+}
+
+const extractOpenDocumentText = (entries) => {
+  if (!entries.has('content.xml')) return ''
+  const xml = entries.get('content.xml').toString('utf8')
+    .replace(/<text:line-break\s*\/>/g, '\n')
+    .replace(/<text:tab\s*\/>/g, '\t')
+    .replace(/<draw:frame[^>]*>/g, '\n')
+    .replace(/<\/draw:frame>/g, '\n')
+
+  const stripped = xml.replace(/<[^>]+>/g, ' ')
+  return normalizeWhitespace(decodeXmlEntities(stripped))
+}
+
+const readPdf = async (filePath) => {
+  const dataBuffer = await fs.readFile(filePath)
+  const pdfData = await pdf(dataBuffer)
+  return pdfData.text.trim()
+}
+
+const readDocxLike = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractDocxText(entries)
+}
+
+const readPptxLike = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractPptxText(entries)
+}
+
+const readKeynote = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractKeynoteText(entries)
+}
+
+const readXlsxLike = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractXlsxText(entries)
+}
+
+const readOpenDocument = async (filePath) => {
+  const buffer = await fs.readFile(filePath)
+  const entries = parseZipEntries(buffer)
+  return extractOpenDocumentText(entries)
+}
+
+const readRtf = async (filePath) => {
+  const raw = await fs.readFile(filePath, 'utf8')
+
+  const normalized = raw
+    .replace(/\\'([0-9a-fA-F]{2})/g, (_, hex) => {
+      const codePoint = parseInt(hex, 16)
+      return Number.isNaN(codePoint) ? '' : String.fromCharCode(codePoint)
+    })
+    .replace(/\\par[d]?/g, '\n')
+    .replace(/\\tab/g, '\t')
+    .replace(/\\line/g, '\n')
+    .replace(/\\\\/g, '\\')
+    .replace(/\\~|\\-/g, ' ')
+    .replace(/\\[^\s]+ ?/g, '')
+    .replace(/[{}]/g, '')
+
+  return normalizeWhitespace(normalized)
+}
+
+module.exports = async ({ filePath, convertBinary = false, verbose = false }) => {
+  const ext = path.extname(filePath).toLowerCase()
+  const fileName = path.basename(filePath)
+
+  logVerbose(verbose, `📚 Reading ${fileName} (extension: ${ext || 'none'})`)
+
+  if (ext === '.pdf') {
+    logVerbose(verbose, '📑 Parsing PDF document')
+    return readPdf(filePath)
+  }
+
+  if (DOCX_LIKE_EXTENSIONS.has(ext)) {
+    logVerbose(verbose, '📝 Parsing DOCX-like archive')
+    return readDocxLike(filePath)
+  }
+
+  if (PPTX_LIKE_EXTENSIONS.has(ext)) {
+    logVerbose(verbose, '🖼️ Parsing PPTX-like presentation')
+    return readPptxLike(filePath)
+  }
+
+  if (XLSX_LIKE_EXTENSIONS.has(ext)) {
+    logVerbose(verbose, '📊 Parsing XLSX-like spreadsheet')
+    return readXlsxLike(filePath)
+  }
+
+  if (KEYNOTE_EXTENSIONS.has(ext)) {
+    logVerbose(verbose, '🗣️ Parsing Keynote presentation bundle')
+    return readKeynote(filePath)
+  }
+
+  if (OPEN_DOCUMENT_TEXT_EXTENSIONS.has(ext) || OPEN_DOCUMENT_PRESENTATION_EXTENSIONS.has(ext) || OPEN_DOCUMENT_SPREADSHEET_EXTENSIONS.has(ext)) {
+    logVerbose(verbose, '🧭 Parsing OpenDocument file')
+    return readOpenDocument(filePath)
+  }
+
+  if (ext === '.rtf') {
+    logVerbose(verbose, '📜 Parsing RTF document')
+    return readRtf(filePath)
+  }
+
+  if (BINARY_OFFICE_WARNINGS[ext]) {
+    if (convertBinary) {
+      logVerbose(verbose, `⚙️ Converting legacy ${ext} file for ${fileName}`)
+      const { tempPath, cleanup } = await convertBinaryOfficeToDocx({ filePath, ext, verbose })
+      try {
+        const text = await readDocxLike(tempPath)
+        logVerbose(verbose, `🧾 Extracted text from converted document at ${tempPath}`)
+        return text
+      } finally {
+        await cleanup()
+        logVerbose(verbose, `🧹 Cleaned temporary files for ${fileName}`)
+      }
+    }
+
+    logVerbose(verbose, `⚠️ Conversion disabled for ${fileName}; raising warning`)
+    throw new Error(BINARY_OFFICE_WARNINGS[ext])
+  }
+
+  logVerbose(verbose, '📄 Reading file as UTF-8 text')
+  const content = await fs.readFile(filePath, 'utf8')
+  return typeof content === 'string' ? content : content.toString('utf8')
 }

--- a/src/supportedExtensions.js
+++ b/src/supportedExtensions.js
@@ -26,6 +26,15 @@ module.exports = [
   // other
   '.txt', '.log', '.diff', '.patch', '.proto', '.tex',
 
+  // office documents
+  '.doc', '.docx', '.docm', '.dot', '.dotx', '.dotm', '.rtf', '.odt',
+
+  // office presentations
+  '.ppt', '.pptx', '.pptm', '.pps', '.ppsx', '.ppsm', '.pot', '.potx', '.potm', '.key', '.odp',
+
+  // office spreadsheets
+  '.xls', '.xlsx', '.xlsm', '.xlsb', '.xlt', '.xltx', '.xltm', '.ods',
+
   // image files
   '.jpg', '.jpeg', '.png', '.bmp', '.tif', '.tiff',
 


### PR DESCRIPTION
## Summary
- add persistent CLI switches to control filename and metadata hints and record the chosen values in run logs
- surface filesystem metadata and the original filename to the rename prompt and stored log entries
- cap prompt content and trim long excerpts so generated requests stay within the model context window

## Testing
- npx standard

------
https://chatgpt.com/codex/tasks/task_e_68cdb7d76578833091b15c74a73a3b0e