### PR TITLE
Fix duplicate helper declarations in processFile

### DIFF
--- a/src/processFile.js
+++ b/src/processFile.js
@@ -136,35 +136,6 @@ const promptForConfirmation = async ({ question, forceChange, nonInteractiveMess
   })
 }
 
-const logVerbose = (verbose, message) => {
-  if (!verbose) return
-  console.log(message)
-}
-
-const promptForConfirmation = async ({ question, forceChange, nonInteractiveMessage }) => {
-  if (forceChange) return true
-
-  if (!process.stdin.isTTY) {
-    if (nonInteractiveMessage) {
-      console.log(nonInteractiveMessage)
-    }
-    return false
-  }
-
-  return await new Promise(resolve => {
-    const rl = readline.createInterface({
-      input: process.stdin,
-      output: process.stdout
-    })
-
-    rl.question(question, answer => {
-      rl.close()
-      const normalized = answer.trim().toLowerCase()
-      resolve(normalized === 'y' || normalized === 'yes')
-    })
-  })
-}
-
 module.exports = async options => {
   const { filePath } = options
   let framesOutputDir


### PR DESCRIPTION
## Summary
- remove the duplicate `logVerbose` and `promptForConfirmation` helper definitions from `processFile.js`
- rely on the enhanced prompt handler that supports the default acceptance flag

## Testing
- npm test *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68d47cd817648330886920a708365504