### PR TITLE
fix: wrap CLI help output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A Node.js CLI that uses local or hosted multimodal LLMs to inspect a file's cont
 ## Overview
 `ai-renamer` is a cross-platform CLI for renaming files according to the information inside them. Point the command at a folder or a single file and the tool will extract context (text, OCR frames, metadata) before asking an LLM to craft a concise filename. Multiple providers are supported, including Ollama, LM Studio, and OpenAI.
 
+> **Attribution**: This project is a fork of [ozgrozer/ai-renamer](https://github.com/ozgrozer/ai-renamer) by Özgür Özer. The upstream repository contains the original implementation and ongoing development by the creator.
+
 The CLI stores your preferred switches (provider, model, case style, subject-organization behavior, etc.) in a local config file so recurring workflows stay one command away.
 
 ## Key Features

--- a/src/cli/createCli.js
+++ b/src/cli/createCli.js
@@ -125,7 +125,9 @@ function createCli (config = {}) {
       type: 'string'
     })
     .example('$0 ~/Downloads/Pitches --dry-run --summary', 'Preview renames and print a summary report')
-    .wrap(null)
+
+  const wrapWidth = typeof parser.terminalWidth === 'function' ? parser.terminalWidth() : 80
+  parser.wrap(Math.min(120, wrapWidth))
 
   const defaults = { ...defaultOptions, ...config }
 


### PR DESCRIPTION
## Summary
- restore yargs help text wrapping so long option descriptions are not truncated in narrow terminals
- cap the wrap width to at most 120 characters while respecting the detected terminal width

## Testing
- node src/index.js --help

------
https://chatgpt.com/codex/tasks/task_e_68e04792a99483309ab931114dfe3553