### PR TITLE
fix: guard CLI help wrap width

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A Node.js CLI that uses local or hosted multimodal LLMs to inspect a file's cont
 ## Overview
 `ai-renamer` is a cross-platform CLI for renaming files according to the information inside them. Point the command at a folder or a single file and the tool will extract context (text, OCR frames, metadata) before asking an LLM to craft a concise filename. Multiple providers are supported, including Ollama, LM Studio, and OpenAI.
 
+> **Attribution**: This project is a fork of [ozgrozer/ai-renamer](https://github.com/ozgrozer/ai-renamer) by Özgür Özer. The upstream repository contains the original implementation and ongoing development by the creator.
+
 The CLI stores your preferred switches (provider, model, case style, subject-organization behavior, etc.) in a local config file so recurring workflows stay one command away.
 
 ## Key Features

--- a/src/cli/createCli.js
+++ b/src/cli/createCli.js
@@ -125,7 +125,10 @@ function createCli (config = {}) {
       type: 'string'
     })
     .example('$0 ~/Downloads/Pitches --dry-run --summary', 'Preview renames and print a summary report')
-    .wrap(null)
+
+  const detectedWidth = typeof parser.terminalWidth === 'function' ? parser.terminalWidth() : undefined
+  const wrapWidth = Number.isFinite(detectedWidth) && detectedWidth > 0 ? detectedWidth : 80
+  parser.wrap(Math.min(120, wrapWidth))
 
   const defaults = { ...defaultOptions, ...config }
 


### PR DESCRIPTION
## Summary
- guard the CLI help wrap width by falling back to 80 columns when the terminal width cannot be detected

## Testing
- node src/index.js --help

------
https://chatgpt.com/codex/tasks/task_e_68e04792a99483309ab931114dfe3553