### PR TITLE
fix: broaden cli help width detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ A Node.js CLI that uses local or hosted multimodal LLMs to inspect a file's cont
 ## Overview
 `ai-renamer` is a cross-platform CLI for renaming files according to the information inside them. Point the command at a folder or a single file and the tool will extract context (text, OCR frames, metadata) before asking an LLM to craft a concise filename. Multiple providers are supported, including Ollama, LM Studio, and OpenAI.
 
+> **Attribution**: This project is a fork of [ozgrozer/ai-renamer](https://github.com/ozgrozer/ai-renamer) by Özgür Özer. The upstream repository contains the original implementation and ongoing development by the creator.
+
 The CLI stores your preferred switches (provider, model, case style, subject-organization behavior, etc.) in a local config file so recurring workflows stay one command away.
 
 ## Key Features

--- a/src/cli/createCli.js
+++ b/src/cli/createCli.js
@@ -1,5 +1,6 @@
 const yargs = require('yargs/yargs')
 const { hideBin } = require('yargs/helpers')
+const process = require('process')
 
 const defaultOptions = {
   provider: 'ollama',
@@ -125,7 +126,17 @@ function createCli (config = {}) {
       type: 'string'
     })
     .example('$0 ~/Downloads/Pitches --dry-run --summary', 'Preview renames and print a summary report')
-    .wrap(null)
+
+  const detectedWidth = typeof parser.terminalWidth === 'function' ? parser.terminalWidth() : undefined
+  const stdoutWidth = process.stdout && Number.isFinite(process.stdout.columns) ? process.stdout.columns : undefined
+  const stderrWidth = process.stderr && Number.isFinite(process.stderr.columns) ? process.stderr.columns : undefined
+  const envWidth = Number.isFinite(Number(process.env.COLUMNS)) ? Number(process.env.COLUMNS) : undefined
+
+  const candidateWidths = [detectedWidth, stdoutWidth, stderrWidth, envWidth]
+    .filter((value) => Number.isFinite(value) && value > 0)
+
+  const wrapWidth = candidateWidths.length > 0 ? Math.max(...candidateWidths) : 120
+  parser.wrap(Math.min(120, Math.max(60, wrapWidth)))
 
   const defaults = { ...defaultOptions, ...config }
 


### PR DESCRIPTION
## Summary
- collect terminal width hints from stdout, stderr, environment, and yargs
- default CLI help wrapping to a generous width so long descriptions remain on one line

## Testing
- node src/index.js --help

------
https://chatgpt.com/codex/tasks/task_e_68e04792a99483309ab931114dfe3553