### PR TITLE
Add append-date option for metadata-backed filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ Options:
                                 subject names                            [string]
       --dry-run                 Preview suggestions without renaming     [boolean]
       --summary                 Print a summary report after the run     [boolean]
-      --append-date             Append metadata/creation date to names   [boolean]
+      --append-date             Ask the model to append the most relevant
+                                metadata/creation date (YYYY-MM-DD)      [boolean]
       --max-file-size           Skip files larger than the given size in MB
                                                                       [number]
       --only-extensions         Only process files with these extensions

--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Options:
                                 subject names                            [string]
       --dry-run                 Preview suggestions without renaming     [boolean]
       --summary                 Print a summary report after the run     [boolean]
+      --append-date             Append metadata/creation date to names   [boolean]
       --max-file-size           Skip files larger than the given size in MB
                                                                       [number]
       --only-extensions         Only process files with these extensions

--- a/src/cli/createCli.js
+++ b/src/cli/createCli.js
@@ -23,7 +23,8 @@ const defaultOptions = {
   ignoreExtensions: '',
   organizeBySubject: false,
   subjectDestination: '',
-  moveUnknownSubjects: false
+  moveUnknownSubjects: false,
+  appendDate: false
 }
 
 const CLI_OPTIONS = {
@@ -115,6 +116,12 @@ const CLI_OPTIONS = {
   },
   moveUnknownSubjects: {
     describe: 'Move low-confidence subjects into an Unknown folder',
+    type: 'boolean'
+  },
+  appendDate: {
+    cliName: 'append-date',
+    defaultKey: 'appendDate',
+    describe: 'Append the most relevant date (metadata or creation) in YYYY-MM-DD format',
     type: 'boolean'
   },
   jsonMode: {

--- a/src/config/configStore.js
+++ b/src/config/configStore.js
@@ -23,7 +23,8 @@ const PERSISTED_KEYS = new Set([
   'organizeBySubject',
   'subjectDestination',
   'moveUnknownSubjects',
-  'jsonMode'
+  'jsonMode',
+  'appendDate'
 ])
 
 async function loadConfig () {

--- a/src/core/promptBuilder.js
+++ b/src/core/promptBuilder.js
@@ -1,5 +1,20 @@
+const { getDateCandidates } = require('../utils/fileDates')
+
 function buildDefaultSystemMessage (options) {
-  return `You are an analyst tasked with renaming downloaded diligence artifacts. Read the provided context and return a JSON object with the following shape:\n{\n  "filename": string,\n  "subject": string | null,\n  "subject_confidence": number (0-1),\n  "summary": string\n}.\n- The filename MUST be concise, descriptive, and avoid filesystem-invalid characters.\n- Prefer ${options.case || 'kebabCase'} case.\n- Honour the requested language: ${options.language || 'English'}.\n- Subjects represent the company, project, or person tied to the file. Use null if you are unsure.\n- subject_confidence should reflect how certain you are about the subject.`
+  const instructions = [
+    'You are an analyst tasked with renaming downloaded diligence artifacts. Read the provided context and return a JSON object with the following shape:\n{\n  "filename": string,\n  "subject": string | null,\n  "subject_confidence": number (0-1),\n  "summary": string\n}.',
+    '- The filename MUST be concise, descriptive, and avoid filesystem-invalid characters.',
+    `- Prefer ${options.case || 'kebabCase'} case.`,
+    `- Honour the requested language: ${options.language || 'English'}.`,
+    '- Subjects represent the company, project, or person tied to the file. Use null if you are unsure.',
+    '- subject_confidence should reflect how certain you are about the subject.'
+  ]
+
+  if (options.appendDate) {
+    instructions.push('- When date candidates are provided, append the most relevant date to the filename in YYYY-MM-DD format.')
+  }
+
+  return instructions.join('\n')
 }
 
 function buildPrompt ({ content, options, subjectHints, instructionSet }) {
@@ -21,6 +36,21 @@ function buildPrompt ({ content, options, subjectHints, instructionSet }) {
     if (metadataLines.length) {
       segments.push('Metadata:')
       segments.push(...metadataLines)
+    }
+  }
+
+  if (options.appendDate) {
+    const dateCandidates = getDateCandidates(content)
+    segments.push('Append-date mode is enabled. Include the most relevant date in the filename using YYYY-MM-DD format.')
+    if (dateCandidates.length) {
+      segments.push('Available date candidates:')
+      for (const candidate of dateCandidates) {
+        const raw = typeof candidate.rawValue === 'string' ? candidate.rawValue : JSON.stringify(candidate.rawValue)
+        const normalized = candidate.formattedValue ? ` (parsed: ${candidate.formattedValue})` : ''
+        segments.push(`${candidate.source}: ${raw}${normalized}`)
+      }
+    } else {
+      segments.push('No explicit date metadata detected; infer from content if possible.')
     }
   }
 

--- a/src/core/promptBuilder.js
+++ b/src/core/promptBuilder.js
@@ -10,6 +10,9 @@ function buildPrompt ({ content, options, subjectHints, instructionSet }) {
   segments.push(`Extension: ${content.extension}`)
   segments.push(`Size: ${content.sizeBytes} bytes`)
   segments.push(`Modified: ${content.modifiedAt}`)
+  if (content.createdAt) {
+    segments.push(`Created: ${content.createdAt}`)
+  }
 
   if (content.metadata) {
     const metadataLines = Object.entries(content.metadata)

--- a/src/core/runRenamer.js
+++ b/src/core/runRenamer.js
@@ -13,7 +13,6 @@ const { createSubjectManager } = require('./subjectManager')
 const { createSummary } = require('./summary')
 const { parseModelResponse } = require('../utils/parseModelResponse')
 const { createInstructionSet } = require('./instructionSet')
-const { getRelevantDate } = require('../utils/fileDates')
 
 function normaliseModelResult (rawResult) {
   if (!rawResult || typeof rawResult !== 'object') {
@@ -75,7 +74,6 @@ async function runRenamer (targetPath, options, logger) {
 
       logger.info(`Processing ${filePath}`)
       const content = await extractContent(filePath, options)
-      const relevantDate = options.appendDate ? getRelevantDate(content) : null
       const subjectHints = subjectManager ? subjectManager.getHints() : []
       const prompt = buildPrompt({ content, options, subjectHints, instructionSet })
       const modelResponse = await provider.generateFilename(prompt)
@@ -91,10 +89,7 @@ async function runRenamer (targetPath, options, logger) {
       const baseWithoutExt = filename.replace(/\.[^./]+$/, '')
       const formattedBase = applyCase(baseWithoutExt, options.case || 'kebabCase')
       const truncatedBase = options.chars ? truncateFilename(formattedBase, options.chars) : formattedBase
-      const baseWithDate = relevantDate
-        ? [truncatedBase, relevantDate].filter(Boolean).join('-')
-        : truncatedBase
-      const sanitizedName = sanitizeFilename(baseWithDate, extension)
+      const sanitizedName = sanitizeFilename(truncatedBase, extension)
 
       let destinationDirectory = path.dirname(filePath)
       let resolvedSubject = effectiveSubject

--- a/src/extractors/contentExtractor.js
+++ b/src/extractors/contentExtractor.js
@@ -11,11 +11,16 @@ async function extractContent (filePath, options) {
   const baseName = path.basename(filePath)
   const stats = await fs.stat(filePath)
 
+  const createdAt = stats.birthtime instanceof Date && !Number.isNaN(stats.birthtime.getTime())
+    ? stats.birthtime.toISOString()
+    : null
+
   const baseContext = {
     fileName: baseName,
     extension: getExtension(filePath),
     sizeBytes: stats.size,
-    modifiedAt: stats.mtime.toISOString()
+    modifiedAt: stats.mtime.toISOString(),
+    createdAt
   }
 
   if (category === 'text') {

--- a/src/extractors/pdfExtractor.js
+++ b/src/extractors/pdfExtractor.js
@@ -1,5 +1,6 @@
 const fs = require('fs/promises')
 const pdfParse = require('pdf-parse')
+const { parsePdfDate } = require('../utils/fileDates')
 
 async function extractPdf (filePath) {
   const buffer = await fs.readFile(filePath)
@@ -7,7 +8,9 @@ async function extractPdf (filePath) {
   const meta = {
     author: data.info?.Author || '',
     title: data.info?.Title || '',
-    pages: data.numpages
+    pages: data.numpages,
+    creationDate: parsePdfDate(data.info?.CreationDate)?.toISOString() || '',
+    modificationDate: parsePdfDate(data.info?.ModDate)?.toISOString() || ''
   }
   return {
     text: (data.text || '').slice(0, 8000),

--- a/src/utils/fileDates.js
+++ b/src/utils/fileDates.js
@@ -1,0 +1,168 @@
+const METADATA_DATE_KEYS = new Set([
+  'date',
+  'datetime',
+  'creationdate',
+  'createdate',
+  'creationtime',
+  'createdatetime',
+  'moddate',
+  'modifieddate',
+  'modificationdate',
+  'lastmodified',
+  'capturedate',
+  'capturedat',
+  'recordeddate',
+  'recordedat',
+  'timestamp',
+  'filedate',
+  'releasedate',
+  'publishdate',
+  'publisheddate',
+  'issuedate',
+  'shootdate',
+  'productiondate'
+])
+
+function normaliseDateInput (value) {
+  if (!value) return null
+
+  if (value instanceof Date) {
+    if (!Number.isNaN(value.getTime())) {
+      return value
+    }
+    return null
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const date = new Date(value)
+    return Number.isNaN(date.getTime()) ? null : date
+  }
+
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (!trimmed) return null
+
+    const parsed = Date.parse(trimmed)
+    if (!Number.isNaN(parsed)) {
+      return new Date(parsed)
+    }
+
+    const simpleMatch = trimmed.match(/^([0-9]{4})[-_/]?([0-9]{2})[-_/]?([0-9]{2})$/)
+    if (simpleMatch) {
+      const [, year, month, day] = simpleMatch
+      const date = new Date(Number(year), Number(month) - 1, Number(day))
+      return Number.isNaN(date.getTime()) ? null : date
+    }
+  }
+
+  return null
+}
+
+function formatDateForFilename (date) {
+  const year = String(date.getUTCFullYear()).padStart(4, '0')
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function extractMetadataDates (metadata) {
+  if (!metadata || typeof metadata !== 'object') {
+    return []
+  }
+
+  const candidates = []
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (!value) continue
+
+    if (typeof value === 'object' && !Array.isArray(value)) {
+      candidates.push(...extractMetadataDates(value))
+      continue
+    }
+
+    const normalizedKey = key.toLowerCase().replace(/[^a-z]/g, '')
+    if (METADATA_DATE_KEYS.has(normalizedKey)) {
+      candidates.push(value)
+    }
+  }
+
+  return candidates
+}
+
+function getRelevantDate (content) {
+  if (!content || typeof content !== 'object') {
+    return null
+  }
+
+  const candidates = []
+
+  candidates.push(...extractMetadataDates(content.metadata))
+
+  if (content.createdAt) {
+    candidates.push(content.createdAt)
+  }
+
+  if (content.modifiedAt) {
+    candidates.push(content.modifiedAt)
+  }
+
+  for (const candidate of candidates) {
+    const parsed = normaliseDateInput(candidate)
+    if (parsed) {
+      return formatDateForFilename(parsed)
+    }
+  }
+
+  return null
+}
+
+function parsePdfDate (value) {
+  if (!value || typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  if (!trimmed) return null
+
+  const withoutPrefix = trimmed.startsWith('D:') ? trimmed.slice(2) : trimmed
+  const match = withoutPrefix.match(/^(\d{4})(\d{2})?(\d{2})?(\d{2})?(\d{2})?(\d{2})?(Z|[+-]\d{2}'?\d{2}'?)?/) // eslint-disable-line no-useless-escape
+  if (!match) {
+    return null
+  }
+
+  const [
+    ,
+    year,
+    month = '01',
+    day = '01',
+    hour = '00',
+    minute = '00',
+    second = '00',
+    tz = 'Z'
+  ] = match
+
+  let timezone = tz
+  if (timezone && timezone !== 'Z') {
+    const normalised = timezone.replace(/'/g, '')
+    if (/^[+-]\d{4}$/.test(normalised)) {
+      timezone = `${normalised.slice(0, 3)}:${normalised.slice(3)}`
+    } else {
+      timezone = 'Z'
+    }
+  }
+
+  if (!timezone) {
+    timezone = 'Z'
+  }
+
+  const isoString = `${year}-${month}-${day}T${hour}:${minute}:${second}${timezone}`
+  const date = new Date(isoString)
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+module.exports = {
+  getRelevantDate,
+  parsePdfDate,
+  formatDateForFilename,
+  normaliseDateInput
+}


### PR DESCRIPTION
## Summary
- add an --append-date CLI/config option to append the most relevant date to generated filenames
- capture creation and modification metadata (including PDF creation/modification dates) for use in prompts and renaming
- introduce shared utilities for parsing metadata dates and document the new flag

## Testing
- npx standard

------
https://chatgpt.com/codex/tasks/task_e_68e0747260588330bd46e90f168a09e2